### PR TITLE
Continuously monitor and print new comments

### DIFF
--- a/src/julia/redder.py
+++ b/src/julia/redder.py
@@ -9,7 +9,7 @@ load_dotenv()
 # https://www.reddit.com/prefs/apps
 reddit = praw.Reddit(
     client_id=os.getenv("REDDIT_CLIENT_ID"),
-    client_secret=os.getenv("REDDIT_CLEINT_SECRET"),
+    client_secret=os.getenv("REDDIT_CLIENT_SECRET"),
     user_agent=f"redder:comment-scraper:v1.0 (by u/{os.getenv('REDDIT_USERNAME')})",
 )
 
@@ -37,21 +37,29 @@ for idx, submission in enumerate(
 # --- Tracking printed comments ---
 printed_comment_ids = set()
 
+# Seed with existing comments so we only print new ones after startup
+latest_submission.comments.replace_more(limit=0)
+for comment in latest_submission.comments.list():
+    printed_comment_ids.add(comment.id)
+
 # --- Continuous loop ---
-while True:
-    # Expand any "MoreComments" placeholders
-    latest_submission.comments.replace_more(limit=0)
+try:
+    while True:
+        # Expand any "MoreComments" placeholders
+        latest_submission.comments.replace_more(limit=0)
 
-    # Loop through all comments
-    for comment in latest_submission.comments.list():
-        if comment.id not in printed_comment_ids:
-            printed_comment_ids.add(comment.id)  # Mark as printed
+        # Loop through all comments
+        for comment in latest_submission.comments.list():
+            if comment.id not in printed_comment_ids:
+                printed_comment_ids.add(comment.id)  # Mark as printed
 
-            # Print new comment
-            print(f"[{comment.author}] {comment.body}")
-            print("-" * 50)
+                # Print new comment
+                print(f"[{comment.author}] {comment.body}")
+                print("-" * 50)
 
-    # Wait a bit before checking again (to avoid hitting API rate limits)
-    time.sleep(10)
+        # Wait a bit before checking again (to avoid hitting API rate limits)
+        time.sleep(10)
+except KeyboardInterrupt:
+    print("Stopping comment stream. Goodbye.")
 # Daily Discussion Thread for September 03, 2025
 # Weekend Discussion Thread for the Weekend of October 18, 2024


### PR DESCRIPTION
Enable continuous streaming of new Reddit comments with graceful cancellation and correct the client secret environment variable name.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe45b668-4e8f-44bc-a8e2-142be8e090bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe45b668-4e8f-44bc-a8e2-142be8e090bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

