### PR TITLE
Debug redder.py comment fetching loop

### DIFF
--- a/src/julia/redder.py
+++ b/src/julia/redder.py
@@ -41,7 +41,12 @@ comment_idx = 0
 time_sleep = 0
 while True:
     if time_sleep % 5 == 0:
-        latest_submission.comments.replace_more(limit=0)
+        try:
+            latest_submission.refresh()
+        except Exception:
+            latest_submission = reddit.submission(id=submission_id)
+        latest_submission.comment_sort = "new"
+        latest_submission.comments.replace_more(limit=None)
         for comment in latest_submission.comments.list():
 
             if comment.id in printed_comment_ids:


### PR DESCRIPTION
Refresh submission, sort by new, and expand all comments to fetch the latest comments in `redder.py`.

The loop was not pulling in the latest comments because the submission object was stale, `replace_more(limit=0)` prevented the expansion of new replies, and comments were not explicitly sorted by new.

---
<a href="https://cursor.com/background-agent?bcId=bc-64afde8e-da27-42cd-9cb7-9eca98a36bdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-64afde8e-da27-42cd-9cb7-9eca98a36bdc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

