### PR TITLE
Debug discord bot exit and ping command

### DIFF
--- a/src/julia/discorder.py
+++ b/src/julia/discorder.py
@@ -13,6 +13,7 @@ TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 CHANNEL_ID = int(os.getenv("DISCORD_CHANNEL_ID"))
 
 intents = Intents.default()  # set more if you need them
+intents.message_content = True
 client = discord.Client(intents=intents)
 
 


### PR DESCRIPTION
Enable `message_content` intent to allow the bot to process message content and respond to commands like `!ping`.

---
<a href="https://cursor.com/background-agent?bcId=bc-df0cdcc4-f287-4704-bb8e-a298c571edae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df0cdcc4-f287-4704-bb8e-a298c571edae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

