### PR TITLE
Make implied-vs-actual history window a dropdown (5/10/15/20 working days)

### DIFF
--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -1221,9 +1221,12 @@ for ticker in tickers:
 st.divider()
 st.header("📏 Implied vs actual daily moves")
 
-iva_days = st.slider(
-    "Sessions of history",
-    min_value=3, max_value=15, value=5, key="iva_days",
+iva_days = st.selectbox(
+    "History window",
+    options=[5, 10, 15, 20],
+    index=0,
+    format_func=lambda n: f"Last {n} working days",
+    key="iva_days",
 )
 _iva_end = _prev_business_day(date.today())
 st.caption(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to [#17](https://github.com/tekneeq/julia/pull/17): the "Implied vs actual daily moves" section's history window is now a dropdown instead of a slider. Options are **Last 5 / 10 / 15 / 20 working days**, defaulting to 5. The window still ends at the previous business day and skips weekends.

## Testing

- `ruff check` passes and a module-level smoke test (importing the Streamlit app end-to-end) ran clean.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df809b2b-d5f2-4e5d-b982-fae35bbffd13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df809b2b-d5f2-4e5d-b982-fae35bbffd13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

