### PR TITLE
Scheduler: force-run option, run history/status report, and real restart semantics

### DIFF
--- a/restart-oi-scheduler.sh
+++ b/restart-oi-scheduler.sh
@@ -1,3 +1,101 @@
-#!/bin/bash
+#!/usr/bin/env bash
+#
+# Restart (or inspect) the OI snapshot scheduler inside the dashboard
+# container.
+#
+# By default the scheduler now starts DETACHED, so it survives the shell
+# that launched it. Console output goes to logs/oi-scheduler.out on the
+# host; per-fire batch output to logs/oi-scheduler/YYYY-MM-DD.log and
+# per-job output to logs/oi-batch/TICKER-DATE.log.
+#
+# Usage
+#   ./restart-oi-scheduler.sh                restart, detached
+#   ./restart-oi-scheduler.sh --now          restart + fire a batch immediately
+#   ./restart-oi-scheduler.sh --run-once     fire ONE batch now and exit (no restart)
+#   ./restart-oi-scheduler.sh --status       what ran, what's missing (no restart)
+#   ./restart-oi-scheduler.sh --stop         stop the scheduler
+#   ./restart-oi-scheduler.sh --dry-run      print the next 10 fire times
+#   ./restart-oi-scheduler.sh --logs         follow the scheduler console log
+#   ./restart-oi-scheduler.sh --foreground   run attached (previous behaviour)
+#
+# Combine any of the above with:
+#   -t, --tickers SPY,QQQ     -a, --days-ahead 7
+#   -i, --interval-min 15     -w, --workers 4
+#
+# Note: a detached `docker exec` does not survive a container restart, so
+# run this again after ./restart.sh or a host reboot.
 
-docker exec julia-dashboard uv run python scripts/oi_scheduler.py
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CONTAINER="${OI_CONTAINER:-julia-dashboard}"
+SCHED="scripts/oi_scheduler.py"
+OUT_LOG="logs/oi-scheduler.out"
+
+MODE="restart"
+FOREGROUND=0
+PASSTHRU=()
+
+usage() { sed -n '2,/^[^#]/p' "$0" | sed 's/^#//; s/^ //' | sed '$d'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -n|--now)          PASSTHRU+=(--now); shift ;;
+        -r|--run-once)     MODE="run-once"; shift ;;
+        -s|--status)       MODE="status"; shift ;;
+        --stop)            MODE="stop"; shift ;;
+        -d|--dry-run)      MODE="dry-run"; shift ;;
+        -l|--logs)         MODE="logs"; shift ;;
+        -f|--foreground)   FOREGROUND=1; shift ;;
+        -t|--tickers)      PASSTHRU+=(--tickers "$2"); shift 2 ;;
+        -a|--days-ahead)   PASSTHRU+=(--days-ahead "$2"); shift 2 ;;
+        -i|--interval-min) PASSTHRU+=(--interval-min "$2"); shift 2 ;;
+        -w|--workers)      PASSTHRU+=(--workers "$2"); shift 2 ;;
+        -h|--help)         usage; exit 0 ;;
+        *)                 PASSTHRU+=("$1"); shift ;;
+    esac
+done
+
+# Move the collected flags into "$@" — `"${arr[@]}"` on an empty array
+# trips `set -u` on bash 3.2 (still the default on macOS).
+set -- "${PASSTHRU[@]+"${PASSTHRU[@]}"}"
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+    echo "❌ container '$CONTAINER' is not running. Start it with ./restart.sh" >&2
+    exit 1
+fi
+
+TTY=()
+[ -t 0 ] && TTY=(-it)
+
+if [[ "$MODE" == "logs" ]]; then
+    exec docker exec "${TTY[@]+"${TTY[@]}"}" "$CONTAINER" \
+        tail -n 100 -f "$OUT_LOG"
+fi
+
+# status / dry-run / stop / run-once are all short-lived and want their
+# output on your terminal — no detaching, no pid juggling.
+if [[ "$MODE" != "restart" ]]; then
+    exec docker exec "$CONTAINER" uv run python "$SCHED" "--$MODE" "$@"
+fi
+
+if [[ $FOREGROUND -eq 1 ]]; then
+    exec docker exec "${TTY[@]+"${TTY[@]}"}" "$CONTAINER" \
+        uv run python "$SCHED" --replace "$@"
+fi
+
+# Re-quote so args survive the `sh -c` hop into the container.
+QUOTED=""
+for a in --replace "$@"; do QUOTED+=" $(printf '%q' "$a")"; done
+
+docker exec -d "$CONTAINER" sh -c \
+    "mkdir -p logs && exec uv run python $SCHED$QUOTED >> $OUT_LOG 2>&1"
+
+# Confirm it actually came up rather than reporting success for a process
+# that died on startup.
+sleep 3
+echo "── scheduler status ──────────────────────────────────────────────"
+docker exec "$CONTAINER" uv run python "$SCHED" --status "$@" || true
+echo
+echo "Console log: $OUT_LOG   (follow with: $0 --logs)"

--- a/scripts/oi_batch.py
+++ b/scripts/oi_batch.py
@@ -130,11 +130,22 @@ def _extract_saved_path(text: str) -> str | None:
 
 
 def _last_meaningful_line(text: str) -> str:
-    for line in reversed(text.splitlines()):
-        stripped = line.strip()
-        if stripped:
-            return stripped
-    return ""
+    """Best one-line summary of a job's output.
+
+    Prefers an explicit error line, because the genuinely useful message
+    ("❌ Error: RH_USERNAME ... must be set") is usually followed on
+    stderr by unrelated tool chatter (uv deprecation warnings and the
+    like) that would otherwise be all you see in the batch summary.
+    """
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    noise = ("warning:", "warn:", "note:")
+    for line in reversed(lines):
+        if line.startswith("❌") or line.startswith("Error:"):
+            return line
+    for line in reversed(lines):
+        if not line.lower().startswith(noise):
+            return line
+    return lines[-1] if lines else ""
 
 
 def main() -> int:

--- a/scripts/oi_scheduler.py
+++ b/scripts/oi_scheduler.py
@@ -17,6 +17,14 @@ Examples
     # Start with the defaults (SPY, 5 business days ahead)
     ./scripts/oi_scheduler.py
 
+    # Don't wait for the next :00/:30 slot — fire a batch right now, then
+    # settle into the normal schedule
+    ./scripts/oi_scheduler.py --now
+
+    # Fire one batch immediately and exit (no scheduling loop) — handy for
+    # backfilling an expiration that's missing data
+    ./scripts/oi_scheduler.py --run-once
+
     # Different ticker set, longer window
     ./scripts/oi_scheduler.py --tickers SPY,QQQ --days-ahead 7
 
@@ -26,6 +34,9 @@ Examples
     # Preview: show the next 10 scheduled fire times and exit
     ./scripts/oi_scheduler.py --dry-run
 
+    # What has actually run? Coverage of the current window + fire history
+    ./scripts/oi_scheduler.py --status
+
     # Keep the Mac awake while running so the loop doesn't sleep with the lid
     caffeinate -s ./scripts/oi_scheduler.py
 
@@ -34,21 +45,29 @@ Background
     # Detach from the terminal, log to file
     nohup ./scripts/oi_scheduler.py > logs/oi-scheduler.out 2>&1 &
 
+    # Replace whatever is already running (SIGTERM the old pid, then start)
+    ./scripts/oi_scheduler.py --replace
+
     # Stop it later
-    pkill -f oi_scheduler.py
+    ./scripts/oi_scheduler.py --stop
 """
 from __future__ import annotations
 
 import argparse
+import os
 import signal
+import sqlite3
 import subprocess
 import sys
 import time
-from datetime import datetime, time as dtime, timedelta
+from datetime import date, datetime, time as dtime, timedelta, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 BATCH_SCRIPT = REPO_ROOT / "scripts" / "oi_batch.py"
+DB_PATH = REPO_ROOT / ".options_cache" / "predictions.db"
+BATCH_LOG_DIR = REPO_ROOT / "logs" / "oi-batch"
+DEFAULT_PID_FILE = REPO_ROOT / "logs" / "oi-scheduler.pid"
 
 # Market slots (assumed local time on the Mac == ET; set your Mac TZ
 # accordingly, or shift these two constants if you're not on ET).
@@ -115,6 +134,113 @@ def _upcoming_slots(now: datetime, interval_min: int, n: int) -> list[datetime]:
     return slots
 
 
+def _next_business_date(d: date) -> date:
+    while d.weekday() >= 5:
+        d += timedelta(days=1)
+    return d
+
+
+def _add_business_days(d: date, n: int) -> date:
+    while n > 0:
+        d += timedelta(days=1)
+        if d.weekday() < 5:
+            n -= 1
+    return d
+
+
+def _rolling_window(day: date, days_ahead: int) -> list[date]:
+    """Expirations that ``oi_batch.py --rolling-days N`` targets on ``day``.
+
+    Mirrors oi_batch's own math so the status report can tell you what
+    *should* have been captured on any past day, not just today.
+    """
+    start = _next_business_date(day)
+    end = _add_business_days(start, days_ahead - 1)
+    out: list[date] = []
+    d = start
+    while d <= end:
+        if d.weekday() < 5:
+            out.append(d)
+        d += timedelta(days=1)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# PID file — lets "restart" actually restart, and --status know if we're up
+# ---------------------------------------------------------------------------
+# Caveat: pids get recycled. A stale pid file whose number has been reused
+# by an unrelated process would read as "running". The window is small and
+# the blast radius is a refused start, so we don't try to be cleverer.
+
+def _read_pid(pid_file: Path) -> int | None:
+    try:
+        return int(pid_file.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists, just not ours to signal
+    return True
+
+
+def _running_pid(pid_file: Path) -> int | None:
+    """The pid of a live scheduler other than us, if there is one."""
+    pid = _read_pid(pid_file)
+    if pid is None or pid == os.getpid() or not _pid_alive(pid):
+        return None
+    return pid
+
+
+def _write_pid(pid_file: Path) -> None:
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(f"{os.getpid()}\n")
+
+
+def _clear_pid(pid_file: Path) -> None:
+    # Only if it's still ours — a replacement scheduler may have claimed
+    # the file while we were winding down.
+    if _read_pid(pid_file) == os.getpid():
+        pid_file.unlink(missing_ok=True)
+
+
+def _stop_running(pid_file: Path, timeout: float = 30.0) -> bool:
+    """SIGTERM the running scheduler and wait for it to exit.
+
+    The loop only checks its shutdown flag between 5s sleep chunks, and a
+    fire already in flight runs to completion, so we escalate to SIGKILL
+    after ``timeout``. Returns False if nothing was running.
+    """
+    pid = _running_pid(pid_file)
+    if pid is None:
+        return False
+    print(f"[{datetime.now():%H:%M:%S}] stopping scheduler pid {pid}…")
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as e:
+        print(f"  couldn't signal pid {pid}: {e!r}")
+        return False
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _pid_alive(pid):
+            print(f"  pid {pid} exited.")
+            return True
+        time.sleep(0.5)
+    print(f"  pid {pid} still alive after {timeout:.0f}s (mid-batch?) — SIGKILL.")
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+    return True
+
+
 # ---------------------------------------------------------------------------
 # Batch runner
 # ---------------------------------------------------------------------------
@@ -150,6 +276,215 @@ def _run_batch(
         elapsed = time.time() - started
         f.write(f"\n[{datetime.now():%H:%M:%S}] exit={rc} elapsed={elapsed:.1f}s\n")
     return rc, elapsed
+
+
+# ---------------------------------------------------------------------------
+# Status report — "what actually ran, and what's missing?"
+# ---------------------------------------------------------------------------
+
+def _parse_utc(iso_ts: str) -> datetime:
+    return datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+
+
+def _fmt_age(seconds: float) -> str:
+    secs = int(seconds)
+    if secs < 60:
+        return f"{secs}s ago"
+    if secs < 3600:
+        return f"{secs // 60}m ago"
+    if secs < 86400:
+        return f"{secs // 3600}h{(secs % 3600) // 60:02d}m ago"
+    return f"{secs // 86400}d ago"
+
+
+def _query(sql: str, params: tuple = ()) -> list[tuple]:
+    """Read-only query against the snapshot DB. Empty list on any problem
+    (no DB yet, table not created yet, locked, ...) — status should never
+    be the thing that crashes."""
+    if not DB_PATH.exists():
+        return []
+    try:
+        conn = sqlite3.connect(f"file:{DB_PATH}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return []
+    try:
+        return conn.execute(sql, params).fetchall()
+    except sqlite3.Error:
+        return []
+    finally:
+        conn.close()
+
+
+def _captures(
+    tickers: list[str], *, expirations: list[date] | None = None,
+    since: date | None = None,
+) -> list[tuple[str, str, datetime]]:
+    """(ticker, expiration_iso, captured_at_local) rows, oldest first."""
+    where, params = ["1=1"], []
+    if expirations:
+        where.append(
+            "expiration_date IN (%s)" % ",".join("?" * len(expirations))
+        )
+        params.extend(e.isoformat() for e in expirations)
+    if since is not None:
+        midnight_utc = datetime.combine(
+            since, dtime(0, 0)
+        ).astimezone().astimezone(timezone.utc)
+        where.append("captured_at >= ?")
+        params.append(midnight_utc.isoformat(timespec="seconds"))
+    rows = _query(
+        "SELECT ticker, expiration_date, captured_at FROM gex_snapshots "
+        f"WHERE {' AND '.join(where)} ORDER BY captured_at",
+        tuple(params),
+    )
+    wanted = set(tickers)
+    return [
+        (t, exp, _parse_utc(ts).astimezone())
+        for t, exp, ts in rows
+        if not wanted or t in wanted
+    ]
+
+
+def _cluster_fires(times: list[datetime], gap_min: float = 10.0) -> list[datetime]:
+    """Collapse per-job capture times into one timestamp per batch fire.
+
+    Each fire writes one snapshot per (ticker × expiration) a few seconds
+    apart, so raw row counts overstate how often the scheduler fired. Any
+    gap longer than ``gap_min`` starts a new fire.
+    """
+    fires: list[datetime] = []
+    prev: datetime | None = None
+    for t in sorted(times):
+        if prev is None or (t - prev).total_seconds() > gap_min * 60:
+            fires.append(t)
+        prev = t
+    return fires
+
+
+def _batch_job_hint(ticker: str, exp: date) -> str | None:
+    """Last meaningful line of the per-job batch log, if one exists.
+
+    When an expiration has no snapshots, this usually says why — e.g.
+    Robinhood hasn't listed the chain yet, or auth expired.
+    """
+    log = BATCH_LOG_DIR / f"{ticker}-{exp.isoformat()}.log"
+    try:
+        text = log.read_text(errors="replace")
+        age = _fmt_age(time.time() - log.stat().st_mtime)
+    except OSError:
+        return None
+    lines = [ln.strip() for ln in text.splitlines() if ln.strip()]
+    if not lines:
+        return f"{log.relative_to(REPO_ROOT)} ({age}): (empty)"
+    # An error line beats the tool chatter (uv deprecation warnings) that
+    # tends to be the literal last line of a failed job's output.
+    pick = next(
+        (ln for ln in reversed(lines) if ln.startswith(("❌", "Error:"))),
+        None,
+    ) or next(
+        (ln for ln in reversed(lines) if not ln.lower().startswith("warning:")),
+        lines[-1],
+    )
+    return f"{log.relative_to(REPO_ROOT)} ({age}): {pick[:120]}"
+
+
+def _status_report(
+    tickers: list[str], days_ahead: int, pid_file: Path, history_days: int,
+) -> int:
+    now = datetime.now()
+    print(f"oi-scheduler status  ·  {now:%a %Y-%m-%d %H:%M:%S %Z}")
+    print(f"  db: {DB_PATH}{'' if DB_PATH.exists() else '   ← does not exist yet'}")
+
+    # --- is it up? ---------------------------------------------------
+    pid = _running_pid(pid_file)
+    if pid:
+        print(f"\nProcess: ● RUNNING (pid {pid}, pid-file {pid_file.name})")
+    else:
+        stale = _read_pid(pid_file)
+        extra = f" — stale pid-file points at {stale}" if stale else ""
+        print(f"\nProcess: ○ NOT RUNNING{extra}")
+        print("         start it with  ./restart-oi-scheduler.sh --now")
+
+    # --- current window coverage -------------------------------------
+    window = _rolling_window(now.date(), days_ahead)
+    print(
+        f"\nCurrent window ({days_ahead} business days): "
+        f"{window[0]} .. {window[-1]}"
+    )
+    rows = _captures(tickers, expirations=window)
+    by_key: dict[tuple[str, str], list[datetime]] = {}
+    for t, exp, ts in rows:
+        by_key.setdefault((t, exp), []).append(ts)
+
+    print(f"  {'ticker':<7} {'expiration':<17} {'snaps':>6} {'today':>6}  last capture")
+    gaps: list[tuple[str, date]] = []
+    for ticker in tickers:
+        for exp in window:
+            times = by_key.get((ticker, exp.isoformat()), [])
+            today_n = sum(1 for t in times if t.date() == now.date())
+            label = f"{exp} ({exp:%a})"
+            if times:
+                last = max(times)
+                last_str = f"{last:%m-%d %H:%M}  ({_fmt_age((now - last.replace(tzinfo=None)).total_seconds())})"
+                flag = "" if today_n else "   ← nothing today"
+            else:
+                last_str, flag = "never", "   ← NO DATA"
+                gaps.append((ticker, exp))
+            print(
+                f"  {ticker:<7} {label:<17} {len(times):>6} {today_n:>6}  "
+                f"{last_str}{flag}"
+            )
+    for ticker, exp in gaps:
+        hint = _batch_job_hint(ticker, exp)
+        if hint:
+            print(f"      ↳ {ticker} {exp}: {hint}")
+
+    # --- fire history -------------------------------------------------
+    since = now.date() - timedelta(days=history_days)
+    hist = _captures(tickers, since=since)
+    print(f"\nDates it ran (last {history_days} days, by capture day):")
+    if not hist:
+        print("  (no snapshots recorded — the scheduler has never completed a fire)")
+    else:
+        by_day: dict[date, list[tuple[str, datetime]]] = {}
+        for _t, exp, ts in hist:
+            by_day.setdefault(ts.date(), []).append((exp, ts))
+        print(
+            f"  {'day':<15} {'fires':>5}  {'first':>5}  {'last':>5}  "
+            f"expirations covered"
+        )
+        for day in sorted(by_day):
+            entries = by_day[day]
+            times = [ts for _e, ts in entries]
+            fires = _cluster_fires(times)
+            covered = {date.fromisoformat(e) for e, _ts in entries}
+            expected = set(_rolling_window(day, days_ahead))
+            missing = sorted(expected - covered)
+            shown = ", ".join(f"{d:%m-%d}" for d in sorted(covered))
+            miss = (
+                "   ⚠ missing " + ", ".join(f"{d:%m-%d}" for d in missing)
+                if missing else ""
+            )
+            day_str = f"{day:%a %Y-%m-%d}"
+            print(
+                f"  {day_str:<15} {len(fires):>5}  "
+                f"{min(times):%H:%M}  {max(times):%H:%M}  {shown}{miss}"
+            )
+        expected_today = set(_rolling_window(now.date(), days_ahead))
+        covered_today = {
+            date.fromisoformat(e) for _t, e, ts in hist if ts.date() == now.date()
+        }
+        if expected_today - covered_today:
+            print(
+                "\n  ⚠ Today is missing: "
+                + ", ".join(str(d) for d in sorted(expected_today - covered_today))
+                + "\n    Backfill now with:  ./restart-oi-scheduler.sh --run-once"
+            )
+    print(
+        f"\nLogs: {BATCH_LOG_DIR.relative_to(REPO_ROOT)}/ (per job)  ·  "
+        f"logs/oi-scheduler/YYYY-MM-DD.log (per fire)"
+    )
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -205,8 +540,36 @@ def main() -> int:
         help="Where to write per-day batch logs.",
     )
     p.add_argument(
-        "--fire-once-on-start", action="store_true",
+        "--now", "--fire-once-on-start", dest="fire_once_on_start",
+        action="store_true",
         help="Fire immediately on startup, then wait for the next scheduled slot.",
+    )
+    p.add_argument(
+        "--run-once", action="store_true",
+        help="Fire one batch right now and exit — no scheduling loop. Use "
+             "this to backfill an expiration that's missing data.",
+    )
+    p.add_argument(
+        "--pid-file", default=str(DEFAULT_PID_FILE),
+        help=f"Where to track the running scheduler (default: {DEFAULT_PID_FILE}).",
+    )
+    p.add_argument(
+        "--replace", action="store_true",
+        help="Stop an already-running scheduler before starting (restart).",
+    )
+    p.add_argument(
+        "--stop", action="store_true",
+        help="Stop the running scheduler and exit.",
+    )
+    p.add_argument(
+        "--status", action="store_true",
+        help="Show whether the scheduler is up, which expirations in the "
+             "current window have data, and the dates/times it actually "
+             "fired. Exits without touching the scheduler.",
+    )
+    p.add_argument(
+        "--history-days", type=int, default=10,
+        help="How many days of fire history --status prints (default: 10).",
     )
     p.add_argument(
         "--dry-run", action="store_true",
@@ -214,10 +577,28 @@ def main() -> int:
     )
     args = p.parse_args()
 
+    # Detached runs redirect stdout to a file, which makes it block-
+    # buffered — the log would sit empty for hours. Line-buffer it so
+    # `tail -f logs/oi-scheduler.out` shows progress as it happens.
+    sys.stdout.reconfigure(line_buffering=True)
+
     if args.interval_min < 1 or 60 % args.interval_min != 0:
         p.error("--interval-min must divide 60 evenly (e.g. 5, 10, 15, 20, 30, 60).")
 
     log_dir = Path(args.log_dir)
+    pid_file = Path(args.pid_file)
+    tickers = [t.strip().upper() for t in args.tickers.split(",") if t.strip()]
+
+    if args.status:
+        return _status_report(
+            tickers, args.days_ahead, pid_file, args.history_days,
+        )
+
+    if args.stop:
+        if _stop_running(pid_file):
+            return 0
+        print(f"No scheduler running (pid-file {pid_file}).")
+        return 0
 
     if args.dry_run:
         upcoming = _upcoming_slots(datetime.now(), args.interval_min, 10)
@@ -227,8 +608,37 @@ def main() -> int:
             print(f"  {i:2}. {s:%a %Y-%m-%d %H:%M}{settlement}")
         return 0
 
+    if args.run_once:
+        print(
+            f"[{datetime.now():%Y-%m-%d %H:%M:%S}] one-off run  "
+            f"tickers={args.tickers}  days-ahead={args.days_ahead}"
+        )
+        window = _rolling_window(date.today(), args.days_ahead)
+        print(f"  expirations: {', '.join(str(d) for d in window)}")
+        rc, elapsed = _run_batch(
+            args.tickers, args.days_ahead, args.workers,
+            refresh_cache=not args.no_refresh_cache,
+            log_dir=log_dir,
+        )
+        print(
+            f"[{datetime.now():%H:%M:%S}] batch "
+            f"{'OK' if rc == 0 else f'FAIL rc={rc}'} ({elapsed:.1f}s)"
+        )
+        return rc
+
+    if args.replace:
+        _stop_running(pid_file)
+    elif (existing := _running_pid(pid_file)) is not None:
+        print(
+            f"A scheduler is already running (pid {existing}). "
+            f"Use --replace to restart it, or --stop to shut it down.",
+            file=sys.stderr,
+        )
+        return 1
+
     signal.signal(signal.SIGINT, _handle_signal)
     signal.signal(signal.SIGTERM, _handle_signal)
+    _write_pid(pid_file)
 
     print(
         f"[{datetime.now():%Y-%m-%d %H:%M:%S}] scheduler starting  "
@@ -241,58 +651,61 @@ def main() -> int:
     for s in upcoming:
         print(f"    · {s:%a %H:%M}")
 
-    if args.fire_once_on_start:
-        _run_batch(
-            args.tickers, args.days_ahead, args.workers,
-            refresh_cache=not args.no_refresh_cache,
-            log_dir=log_dir,
-        )
-
-    while not _shutdown:
-        target = _next_slot(datetime.now(), args.interval_min)
-        wait_sec = (target - datetime.now()).total_seconds()
-        wait_min = wait_sec / 60
-        wait_str = (
-            f"{wait_sec:.0f}s" if wait_sec < 60
-            else f"{wait_min:.1f}m" if wait_min < 60
-            else f"{wait_min / 60:.1f}h"
-        )
-        print(
-            f"[{datetime.now():%H:%M:%S}] sleeping "
-            f"{wait_str} → next fire at {target:%a %H:%M}"
-        )
-        _sleep_until(target)
-        if _shutdown:
-            break
-
-        is_settlement = target.time() == POST_CLOSE
-        # Settlement always refreshes; intraday obeys --no-refresh-cache flag.
-        refresh_cache = True if is_settlement else (not args.no_refresh_cache)
-        try:
-            rc, elapsed = _run_batch(
+    try:
+        if args.fire_once_on_start:
+            _run_batch(
                 args.tickers, args.days_ahead, args.workers,
-                refresh_cache=refresh_cache,
+                refresh_cache=not args.no_refresh_cache,
                 log_dir=log_dir,
             )
-            tag = "settlement" if is_settlement else "intraday"
-            status = "OK" if rc == 0 else f"FAIL rc={rc}"
-            # A real batch takes 10s+ per ticker/date. Anything under a
-            # second means every job died before doing work — usually a
-            # bad CLI flag or a hard import error. Flag it loudly so it
-            # can't hide across many quiet cron cycles.
-            if elapsed < 1.0 and rc != 0:
-                print(
-                    f"[{datetime.now():%H:%M:%S}] ⚠️  {tag} batch died in "
-                    f"{elapsed:.1f}s with rc={rc} — likely a CLI/argparse "
-                    f"error. See {log_dir}/{datetime.now():%Y-%m-%d}.log"
+
+        while not _shutdown:
+            target = _next_slot(datetime.now(), args.interval_min)
+            wait_sec = (target - datetime.now()).total_seconds()
+            wait_min = wait_sec / 60
+            wait_str = (
+                f"{wait_sec:.0f}s" if wait_sec < 60
+                else f"{wait_min:.1f}m" if wait_min < 60
+                else f"{wait_min / 60:.1f}h"
+            )
+            print(
+                f"[{datetime.now():%H:%M:%S}] sleeping "
+                f"{wait_str} → next fire at {target:%a %H:%M}"
+            )
+            _sleep_until(target)
+            if _shutdown:
+                break
+
+            is_settlement = target.time() == POST_CLOSE
+            # Settlement always refreshes; intraday obeys --no-refresh-cache.
+            refresh_cache = True if is_settlement else (not args.no_refresh_cache)
+            try:
+                rc, elapsed = _run_batch(
+                    args.tickers, args.days_ahead, args.workers,
+                    refresh_cache=refresh_cache,
+                    log_dir=log_dir,
                 )
-            else:
-                print(
-                    f"[{datetime.now():%H:%M:%S}] {tag} batch {status}  "
-                    f"({elapsed:.1f}s)"
-                )
-        except Exception as e:  # noqa: BLE001
-            print(f"[{datetime.now():%H:%M:%S}] batch raised: {e!r}")
+                tag = "settlement" if is_settlement else "intraday"
+                status = "OK" if rc == 0 else f"FAIL rc={rc}"
+                # A real batch takes 10s+ per ticker/date. Anything under a
+                # second means every job died before doing work — usually a
+                # bad CLI flag or a hard import error. Flag it loudly so it
+                # can't hide across many quiet cron cycles.
+                if elapsed < 1.0 and rc != 0:
+                    print(
+                        f"[{datetime.now():%H:%M:%S}] ⚠️  {tag} batch died in "
+                        f"{elapsed:.1f}s with rc={rc} — likely a CLI/argparse "
+                        f"error. See {log_dir}/{datetime.now():%Y-%m-%d}.log"
+                    )
+                else:
+                    print(
+                        f"[{datetime.now():%H:%M:%S}] {tag} batch {status}  "
+                        f"({elapsed:.1f}s)"
+                    )
+            except Exception as e:  # noqa: BLE001
+                print(f"[{datetime.now():%H:%M:%S}] batch raised: {e!r}")
+    finally:
+        _clear_pid(pid_file)
 
     print(f"[{datetime.now():%H:%M:%S}] scheduler stopped.")
     return 0

--- a/src/julia/main.py
+++ b/src/julia/main.py
@@ -50,7 +50,10 @@ def ensure_logged_in(func):
                     "❌ Error: RH_USERNAME and RH_PASSWORD must be set in environment variables or .env file"
                 )
                 click.echo("Please set these credentials and try again.")
-                return
+                # Exit non-zero so batch/cron callers can tell this failed.
+                # Returning silently made `oi_batch.py` report every job as
+                # OK while writing no snapshots at all.
+                raise SystemExit(1)
 
             click.echo("🔐 Logging in to Robinhood...")
             try:
@@ -58,7 +61,7 @@ def ensure_logged_in(func):
                 click.echo("✅ Successfully logged in to Robinhood")
             except Exception as e:
                 click.echo(f"❌ Login failed: {e}")
-                return
+                raise SystemExit(1) from e
 
         return func(*args, **kwargs)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a force-run option and a "what actually ran" report to `restart-oi-scheduler.sh`, and fixes a silent-failure hole that let missing data go unnoticed.

```
./restart-oi-scheduler.sh --now        # restart + fire a batch immediately
./restart-oi-scheduler.sh --run-once   # fire ONE batch now and exit (backfill)
./restart-oi-scheduler.sh --status     # what ran, what's missing
```

## `--status` output

```
Process: ○ NOT RUNNING
         start it with  ./restart-oi-scheduler.sh --now

Current window (5 business days): 2026-07-31 .. 2026-08-06
  ticker  expiration         snaps  today  last capture
  SPY     2026-07-31 (Fri)       8      0  07-30 19:55  (17h55m ago)   ← nothing today
  SPY     2026-08-03 (Mon)       6      0  07-30 19:55  (17h55m ago)   ← nothing today
  SPY     2026-08-06 (Thu)       0      0  never   ← NO DATA
      ↳ SPY 2026-08-06: logs/oi-batch/SPY-2026-08-06.log (1m ago): ❌ Error: RH_USERNAME and RH_PASSWORD must be set

Dates it ran (last 10 days, by capture day):
  day             fires  first   last  expirations covered
  Wed 2026-07-29      2  15:00  19:55  07-29, 07-30, 07-31, 08-03, 08-04
  Thu 2026-07-30      2  15:00  19:55  07-30, 07-31, 08-03, 08-04, 08-05

  ⚠ Today is missing: 2026-07-31, 2026-08-03, 2026-08-04, 2026-08-05, 2026-08-06
    Backfill now with:  ./restart-oi-scheduler.sh --run-once
```

Fires are reconstructed by clustering snapshot capture times (any gap > 10 min starts a new fire), so the count reflects batch runs rather than the one-row-per-expiration the DB stores. Each past day is compared against the rolling window that *would* have applied on that day, which is what surfaces the `⚠ missing` markers.

## Three bugs found along the way

1. **Auth failures were invisible.** `ensure_logged_in` returned silently when credentials were missing or login failed, so `lia oi-dashboard` exited 0 and `oi_batch.py` printed `5/5 succeeded` while writing no snapshots. Now exits non-zero, so the batch reports `FAIL` and the scheduler logs it.
2. **The batch summary showed the wrong line.** `_last_meaningful_line` picked the literal last line of output, which for a failed job is uv's deprecation warning on stderr rather than the actual error. Now prefers an error line.
3. **"restart" never restarted anything.** The script ran `docker exec` in the foreground with no `-d`, so the scheduler died with the shell that launched it, and it never stopped an existing scheduler — so repeated runs could leave several going at once.

## Changes

`scripts/oi_scheduler.py`
- `--now` (alias of the existing `--fire-once-on-start`) and `--run-once` for a single batch with no scheduling loop.
- `--status` plus `--history-days N` (default 10). Reads the snapshot DB via stdlib `sqlite3` in read-only mode, keeping the module dependency-free, and degrades to an empty report rather than crashing if the DB is absent or locked.
- Pid file (`logs/oi-scheduler.pid`) with `--replace` and `--stop`. `--replace` sends SIGTERM and escalates to SIGKILL after 30s, since a fire already in flight runs to completion. Starting without `--replace` while one is live now refuses rather than silently doubling up.
- stdout is line-buffered so detached runs stream into their log instead of sitting empty for hours.

`restart-oi-scheduler.sh`
- Detached by default; `--foreground` keeps the previous attached behaviour.
- Modes: `--now`, `--run-once`, `--status`, `--stop`, `--dry-run`, `--logs`, `--help`; pass-through for `--tickers`, `--days-ahead`, `--interval-min`, `--workers`.
- After a detached start it waits briefly and prints `--status`, so a process that dies on startup isn't reported as success.

## Testing

- Exercised the pid lifecycle against real processes: start, refuse-double-start, `--replace` (confirmed the old pid was reaped and a new one claimed the file), `--stop`, and stop-when-nothing-running.
- `--run-once` against a credential-less environment: confirmed it now exits 2 with all five jobs marked `FAIL` and the real error in the summary — the same scenario previously reported `5/5 succeeded`.
- `--status` against a seeded DB reproducing the reported symptom: correctly flagged 08-06 as `NO DATA`, marked the other four expirations as having nothing today, listed per-day fire history with first/last times, and pointed at the batch log line explaining the failure.
- All shell modes verified against a stub `docker` to confirm the composed commands and that arguments survive the `sh -c` hop (including comma-separated tickers).
- `ruff check scripts/` passes. `src/julia/main.py` has 24 pre-existing lint errors; verified the count is identical before and after this change.

## Note on the 08-06 gap

`--status` is the tool for diagnosing this, but the likely cause is visible from the code: the old script ran the scheduler attached, so it very plausibly died when the launching shell exited, and nothing has fired since. 08-06 only entered the 5-day rolling window today (Jul 31), so it would be the first date to show as completely missing while the earlier four still have data from previous days. Run `./restart-oi-scheduler.sh --status` to confirm, then `--now` to restart with an immediate fire.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df809b2b-d5f2-4e5d-b982-fae35bbffd13?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df809b2b-d5f2-4e5d-b982-fae35bbffd13&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

