### PR TITLE
Chiclets: exclude today — show prior 5 completed sessions

### DIFF
--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -2504,19 +2504,26 @@ def _session_chicklet_fig(
 
 
 def _render_recent_session_chiclets(ticker: str, today: date) -> None:
-    """Last 5 trading days as a horizontal row of compact % path cards."""
+    """Prior 5 completed sessions as a horizontal row of compact % cards.
+
+    Today is excluded — the live session chart above already covers it.
+    Cards with no path yet render empty and fill in as the library
+    densifies (market bars / ticks from the poller).
+    """
     st.markdown("##### 📅 Last 5 sessions")
     st.caption(
-        "Each card is one regular session as % vs that day's prior close. "
-        "Annotated **O / H / L** are the open, high, and low of the move. "
-        "Dotted horizontal bands are the ±1σ / ±2σ / ±3σ implied moves "
-        "priced in *before* the session opened — the same numbers as the "
-        "candles under **Implied vs actual daily moves** "
-        f"(blue / orange / red). Library covers the last "
-        f"{daily_moves_store.KEEP_SESSIONS} completed sessions."
+        "The five most recent **completed** sessions (today excluded) as "
+        "% vs each day's prior close. Annotated **O / H / L** are the "
+        "open, high, and low of the move. Dotted horizontal bands are the "
+        "±1σ / ±2σ / ±3σ implied moves priced in *before* the session "
+        "opened — the same numbers as the candles under **Implied vs "
+        "actual daily moves** (blue / orange / red). Empty cards mean we "
+        "don't have a densified path for that day yet; they fill in as "
+        "history accumulates."
     )
 
-    end = today if today.weekday() < 5 else _prev_business_day(today)
+    # Yesterday (or Friday if today is Mon / weekend) → four more back.
+    end = _prev_business_day(today)
     days = _past_business_days(end, 5)
     iva = _implied_vs_actual_history(ticker, 5, end.isoformat())
     iva_by_day = {h["day"]: h for h in iva}
@@ -2528,7 +2535,7 @@ def _render_recent_session_chiclets(ticker: str, today: date) -> None:
             st.plotly_chart(
                 _session_chicklet_fig(
                     day, path, iva_by_day.get(day),
-                    is_today=(day == today),
+                    is_today=False,
                 ),
                 use_container_width=True,
                 config={"displayModeBar": False},


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The **📅 Last 5 sessions** row no longer includes today (the live session chart already covers it). It now shows the five most recent **completed** sessions: yesterday back through the prior four trading days.

Cards with no densified path yet render empty (`no path`) and fill in as market-bar / tick history accumulates — expected while the poller is new.

## Testing

- Confirmed the day window is `[_prev_business_day(today) − 4 sessions … yesterday]` and never includes today
- AppTest: section caption says “today excluded”; 5 chicklet charts still render (empties included)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d806c8ce-a567-4b65-a965-f4400beee8ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d806c8ce-a567-4b65-a965-f4400beee8ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

