### PR TITLE
Round % axis ticks to two decimals on price-action charts

### DIFF
--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -2535,6 +2535,7 @@ def _render_today_price_chart(ticker: str, today: date, status: dict) -> None:
             ],
             tickformat="+.2f",
             ticksuffix="%",
+            hoverformat="+.2f",
             showgrid=False,
             zeroline=False,
             color=_TV_MUTED,
@@ -2706,7 +2707,9 @@ def _twin_fig(
             zeroline=False, color=_TV_MUTED,
         ),
         yaxis=dict(
-            ticksuffix="%", side="right", gridcolor=_TV_GRID,
+            tickformat="+.2f", ticksuffix="%",
+            hoverformat="+.2f",
+            side="right", gridcolor=_TV_GRID,
             zeroline=False, color=_TV_MUTED,
         ),
     ))
@@ -2762,7 +2765,9 @@ def _yesterday_match_fig(
             zeroline=False, color=_TV_MUTED,
         ),
         yaxis=dict(
-            ticksuffix="%", side="right", gridcolor=_TV_GRID,
+            tickformat="+.2f", ticksuffix="%",
+            hoverformat="+.2f",
+            side="right", gridcolor=_TV_GRID,
             zeroline=False, color=_TV_MUTED,
         ),
     ))
@@ -2828,7 +2833,9 @@ def _nextday_only_fig(twin: dict) -> go.Figure:
             zeroline=False, color=_TV_MUTED,
         ),
         yaxis=dict(
-            ticksuffix="%", side="right", gridcolor=_TV_GRID,
+            tickformat="+.2f", ticksuffix="%",
+            hoverformat="+.2f",
+            side="right", gridcolor=_TV_GRID,
             zeroline=False, color=_TV_MUTED,
         ),
     ))
@@ -2994,7 +3001,9 @@ def _session_chicklet_fig(
         ),
         yaxis=dict(
             range=[lo_y, hi_y],
-            ticksuffix="%", side="right", gridcolor=_TV_GRID,
+            tickformat="+.2f", ticksuffix="%",
+            hoverformat="+.2f",
+            side="right", gridcolor=_TV_GRID,
             zeroline=False, color=_TV_MUTED, tickfont=dict(size=9),
             fixedrange=True,
             nticks=5,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Under **Today's price action**, twin panels and last-10 session chiclets showed y-axis percentages with full float precision (long decimals).

**Fix:** set `tickformat="+.2f"` (and matching `hoverformat`) on those % axes so labels read like `+1.42%` instead of `+1.423891...%`.

The live $ chart’s left % axis already used two decimals; this aligns the rest of the section.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d806c8ce-a567-4b65-a965-f4400beee8ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d806c8ce-a567-4b65-a965-f4400beee8ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

