### PR TITLE
Show running git hash and commit time on dashboard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,13 @@ VOLUME ["/app/.options_cache", "/app/plots", "/app/logs"]
 
 EXPOSE 8501
 
+# Baked in by restart.sh / CI so the live dashboard can show which
+# commit it's serving (``.git`` is not copied into the image).
+ARG GIT_SHA=unknown
+ARG GIT_COMMIT_TIME=unknown
+ENV JULIA_GIT_SHA=$GIT_SHA \
+    JULIA_GIT_COMMIT_TIME=$GIT_COMMIT_TIME
+
 ENV UV_NATIVE_TLS=true \
     PYTHONUNBUFFERED=1 \
     STREAMLIT_SERVER_ADDRESS=0.0.0.0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,10 @@
 services:
   dashboard:
-    build: .
+    build:
+      context: .
+      args:
+        GIT_SHA: ${GIT_SHA:-unknown}
+        GIT_COMMIT_TIME: ${GIT_COMMIT_TIME:-unknown}
     image: julia-dashboard:latest
     container_name: julia-dashboard
     ports:
@@ -12,4 +16,7 @@ services:
       - ./logs:/app/logs
     env_file:
       - .env
+    environment:
+      JULIA_GIT_SHA: ${GIT_SHA:-unknown}
+      JULIA_GIT_COMMIT_TIME: ${GIT_COMMIT_TIME:-unknown}
     restart: unless-stopped

--- a/restart.sh
+++ b/restart.sh
@@ -1,13 +1,28 @@
 #!/bin/bash
+set -euo pipefail
+cd "$(dirname "$0")"
+
 git pull
-docker build -t julia-dashboard:latest .
+
+GIT_SHA="$(git rev-parse --short HEAD)"
+# Committer timestamp (= merge time for merge commits on main).
+GIT_COMMIT_TIME="$(git show -s --format=%cI HEAD)"
+
+docker build \
+    --build-arg "GIT_SHA=${GIT_SHA}" \
+    --build-arg "GIT_COMMIT_TIME=${GIT_COMMIT_TIME}" \
+    -t julia-dashboard:latest .
 docker rm -f julia-dashboard
 docker run -d --name julia-dashboard --restart unless-stopped \
     -p 8501:8501 \
     --memory=3g --memory-swap=3g \
-    -v $(pwd)/.options_cache:/app/.options_cache \
-    -v $(pwd)/plots:/app/plots \
-    -v $(pwd)/logs:/app/logs \
-    -v $(pwd)/.tokens:/root/.tokens \
+    -v "$(pwd)/.options_cache:/app/.options_cache" \
+    -v "$(pwd)/plots:/app/plots" \
+    -v "$(pwd)/logs:/app/logs" \
+    -v "$(pwd)/.tokens:/root/.tokens" \
     --env-file .env \
+    -e "JULIA_GIT_SHA=${GIT_SHA}" \
+    -e "JULIA_GIT_COMMIT_TIME=${GIT_COMMIT_TIME}" \
     julia-dashboard:latest
+
+echo "Started julia-dashboard at ${GIT_SHA} (${GIT_COMMIT_TIME})"

--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -24,6 +24,7 @@ import time
 from collections import Counter
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from zoneinfo import ZoneInfo
 
 import math
 
@@ -152,9 +153,12 @@ def _running_git_revision() -> tuple[str, str]:
 
     if when_raw:
         try:
-            # Handle trailing Z / offset; show local wall time + zone.
+            # Always show US/Eastern — matches the dashboard's market clock.
             dt = datetime.fromisoformat(when_raw.replace("Z", "+00:00"))
-            when_label = dt.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+            when_label = (
+                dt.astimezone(ZoneInfo("America/New_York"))
+                .strftime("%Y-%m-%d %H:%M:%S ET")
+            )
         except ValueError:
             when_label = when_raw
     else:

--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -120,6 +120,48 @@ def _format_age(secs: int) -> str:
     return f"{secs // 86400}d ago"
 
 
+def _running_git_revision() -> tuple[str, str]:
+    """``(short_sha, commit_time_label)`` for the build this process serves.
+
+    Prefers ``JULIA_GIT_SHA`` / ``JULIA_GIT_COMMIT_TIME`` baked in by
+    ``restart.sh`` (Docker images have no ``.git``). Falls back to a
+    local ``git`` call for ``streamlit run`` outside Docker.
+    """
+    sha = (os.environ.get("JULIA_GIT_SHA") or "").strip()
+    when_raw = (os.environ.get("JULIA_GIT_COMMIT_TIME") or "").strip()
+    if not sha or sha == "unknown":
+        try:
+            sha = subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=str(REPO_ROOT),
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            sha = "unknown"
+    if not when_raw or when_raw == "unknown":
+        try:
+            when_raw = subprocess.check_output(
+                ["git", "show", "-s", "--format=%cI", "HEAD"],
+                cwd=str(REPO_ROOT),
+                stderr=subprocess.DEVNULL,
+                text=True,
+            ).strip()
+        except (OSError, subprocess.CalledProcessError):
+            when_raw = ""
+
+    if when_raw:
+        try:
+            # Handle trailing Z / offset; show local wall time + zone.
+            dt = datetime.fromisoformat(when_raw.replace("Z", "+00:00"))
+            when_label = dt.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+        except ValueError:
+            when_label = when_raw
+    else:
+        when_label = "unknown"
+    return sha, when_label
+
+
 def _age_str(path: Path) -> str:
     if not path.exists():
         return "not generated"
@@ -3209,6 +3251,8 @@ def _render_today_and_twins(ticker: str) -> None:
 
 st.set_page_config(page_title="Options OI Dashboard", layout="wide")
 st.title("📊 Options OI — Live Dashboard")
+_git_sha, _git_when = _running_git_revision()
+st.caption(f"Running `{_git_sha}` · committed {_git_when}")
 
 with st.sidebar:
     st.header("Config")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Under **Options OI — Live Dashboard**, add a small caption with the git short SHA and committer timestamp of the build being served (for merge commits on `main`, that’s the merge time), shown in **US/Eastern**.

**How**
- `restart.sh` passes `GIT_SHA` / `GIT_COMMIT_TIME` as Docker build args and runtime env.
- Dockerfile / compose bake `JULIA_GIT_SHA` + `JULIA_GIT_COMMIT_TIME`.
- Dashboard reads those env vars (falls back to local `git` outside Docker) and formats the time as ET.

Example: `Running a21d27e · committed 2026-08-06 10:01:54 ET`

After merge, the auto-deploy will rebuild with the new SHA so you can confirm the live box picked it up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d806c8ce-a567-4b65-a965-f4400beee8ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d806c8ce-a567-4b65-a965-f4400beee8ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

