### PR TITLE
Show last 20 sessions in four rows of five

### DIFF
--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -3157,18 +3157,18 @@ def _session_chicklet_fig(
 
 
 def _render_recent_session_chiclets(ticker: str, today: date) -> None:
-    """Prior 10 completed sessions as two rows of 5 compact % cards.
+    """Prior 20 completed sessions as four rows of 5 compact % cards.
 
     Today is excluded — the live session chart above already covers it.
     Cards with no path yet render empty and fill in as the library
     densifies (market bars / ticks from the poller).
     """
-    n_sessions = 10
+    n_sessions = 20
     per_row = 5
-    st.markdown("##### 📅 Last 10 sessions")
+    st.markdown("##### 📅 Last 20 sessions")
     st.caption(
-        "The ten most recent **completed** sessions (today excluded) as "
-        "% vs each day's prior close — five per row, oldest → newest "
+        "The twenty most recent **completed** sessions (today excluded) "
+        "as % vs each day's prior close — five per row, oldest → newest "
         "left-to-right then top-to-bottom. Annotated **O / H / L** are "
         "the open, high, and low of the move. Every card is centered on "
         "**0% (prior close)** and scaled symmetrically to that day's "
@@ -3180,7 +3180,7 @@ def _render_recent_session_chiclets(ticker: str, today: date) -> None:
         "history accumulates."
     )
 
-    # Yesterday (or Friday if today is Mon / weekend) → nine more back.
+    # Yesterday (or Friday if today is Mon / weekend) → nineteen more back.
     end = _prev_business_day(today)
     days = _past_business_days(end, n_sessions)
     iva = _implied_vs_actual_history(ticker, n_sessions, end.isoformat())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Expand the recent-sessions strip under today's price chart from **10 → 20** completed days (today still excluded).

Layout stays **five per row** (four rows), oldest → newest left-to-right then top-to-bottom. Chicklet scaling / O/H/L / touch-only σ lines unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d806c8ce-a567-4b65-a965-f4400beee8ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d806c8ce-a567-4b65-a965-f4400beee8ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

