### PR TITLE
Taller implied-vs-actual chart for longer history windows

### DIFF
--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -916,18 +916,22 @@ def _render_implied_vs_actual_chart(ticker: str, history: list[dict]) -> None:
     ))
 
     fig.add_hline(y=0, line_color="#999", line_width=1)
+    # Longer windows pack more candles on x — grow the plot so wicks /
+    # σ bands stay readable (5d ≈ 560px, 20d ≈ 800px).
+    n = max(len(history), 1)
+    chart_h = int(min(900, max(560, 400 + 20 * n)))
     fig.update_layout(
         title=f"{ticker} — implied (from prior session) vs actual daily move",
         xaxis_title="Session",
         yaxis_title="Move (% of prior-session spot)",
-        height=420,
+        height=chart_h,
         hovermode="x unified",
         legend=dict(orientation="h", y=1.08, x=0),
-        margin=dict(t=60, l=60, r=20, b=40),
+        margin=dict(t=70, l=60, r=20, b=50),
         xaxis_rangeslider_visible=False,
     )
     fig.update_xaxes(type="category")
-    fig.update_yaxes(ticksuffix="%")
+    fig.update_yaxes(ticksuffix="%", tickformat="+.2f")
 
     st.plotly_chart(fig, use_container_width=True)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The **Implied (from prior session) vs actual daily move** chart stayed at a fixed 420px height, so with 20 working days the candles/σ bands felt cramped.

**Change**
- Scale chart height with the number of days (~560px at 5d → ~800px at 20d, capped at 900).
- Slightly more top/bottom margin; % axis ticks use two decimals.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d806c8ce-a567-4b65-a965-f4400beee8ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d806c8ce-a567-4b65-a965-f4400beee8ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

