### PR TITLE
Fix deploy abort on root-owned pid files

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -34,7 +34,10 @@ fi
 
 # PID files live on the host-mounted logs/ volume and survive container
 # recreates — clear them so we never SIGTERM a recycled PID (e.g. Streamlit).
-rm -f logs/oi-scheduler.pid logs/price-poller.pid
+# They are usually root-owned (written inside the container), so delete
+# via docker exec rather than host ``rm`` (which Permission-denies).
+docker exec julia-dashboard rm -f \
+    logs/oi-scheduler.pid logs/price-poller.pid
 
 log "2/4  restart OI scheduler (detached)"
 ./restart-oi-scheduler.sh

--- a/restart-oi-scheduler.sh
+++ b/restart-oi-scheduler.sh
@@ -91,7 +91,8 @@ for a in --replace "$@"; do QUOTED+=" $(printf '%q' "$a")"; done
 
 # Drop recycled PIDs left on the host-mounted logs/ volume after a
 # container recreate — the Python side also scrubs, but clear eagerly.
-rm -f logs/oi-scheduler.pid
+# Pid files are root-owned (written in-container); delete via docker exec.
+docker exec "$CONTAINER" rm -f logs/oi-scheduler.pid
 
 # ``setsid`` + ignore SIGHUP so the process survives ``docker exec -d``
 # session teardown (plain ``exec uv run`` was dying right after deploy).

--- a/restart-price-poller.sh
+++ b/restart-price-poller.sh
@@ -81,7 +81,8 @@ fi
 QUOTED=""
 for a in --replace "$@"; do QUOTED+=" $(printf '%q' "$a")"; done
 
-rm -f logs/price-poller.pid
+# Pid files are root-owned (written in-container); delete via docker exec.
+docker exec "$CONTAINER" rm -f logs/price-poller.pid
 
 docker exec -d "$CONTAINER" sh -c \
     "mkdir -p logs && setsid uv run python $POLLER$QUOTED >>$OUT_LOG 2>&1 </dev/null"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
`./deploy.sh` aborted right after rebuilding the container:

```text
rm: cannot remove 'logs/oi-scheduler.pid': Permission denied
rm: cannot remove 'logs/price-poller.pid': Permission denied
```

Those pid files are written as **root inside the container** on the mounted `logs/` volume, so host-side `rm` fails and `set -e` stops deploy before the scheduler/poller restart.

**Fix:** delete pid files with `docker exec … rm` instead of host `rm` in `deploy.sh` and both restart helpers.

**Until merged**, on the box you can unblock with:
```bash
docker exec julia-dashboard rm -f logs/oi-scheduler.pid logs/price-poller.pid
./restart-oi-scheduler.sh
./restart-price-poller.sh
./restart-oi-scheduler.sh --run-once
```
Or `git pull` after merge and re-run `./deploy.sh`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d806c8ce-a567-4b65-a965-f4400beee8ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d806c8ce-a567-4b65-a965-f4400beee8ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

