### PR TITLE
Add Tickers tab with Seeking Alpha–style sector/industry browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ lia cache --clear-ticker SPY
 lia cache --clear-all
 ```
 
+#### Sync Robinhood tradable tickers (sector / industry)
+```bash
+# Populate .options_cache/tickers.db for the dashboard Tickers tab
+# (public Robinhood instruments + fundamentals — no login required)
+lia tickers-sync
+```
+
+The Streamlit dashboard (`scripts/oi_dashboard_app.py`) has a top **Tickers** tab
+that browses this cache Seeking Alpha–style: sector → industry → symbol.
+Use **Sync from Robinhood** on that tab (or `lia tickers-sync`) to refresh.
+
 #### Calculate Implied Move
 ```bash
 lia emove --ticker SPY --days 1,3,5 --confidence 0.68,0.95

--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -51,6 +51,8 @@ from julia.main import (  # noqa: E402
     _prepare_oi_series,
 )
 
+import pandas as pd  # noqa: E402
+
 
 # ---------------------------------------------------------------------------
 # Date helpers
@@ -4863,6 +4865,289 @@ def _render_today_and_twins(ticker: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Tickers tab — Seeking Alpha–style sector / industry browser
+# ---------------------------------------------------------------------------
+
+def _fmt_market_cap(value) -> str:
+    if value is None:
+        return "—"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    abs_v = abs(v)
+    if abs_v >= 1e12:
+        return f"${v / 1e12:.2f}T"
+    if abs_v >= 1e9:
+        return f"${v / 1e9:.2f}B"
+    if abs_v >= 1e6:
+        return f"${v / 1e6:.2f}M"
+    return f"${v:,.0f}"
+
+
+def _fmt_ratio(value) -> str:
+    if value is None:
+        return "—"
+    try:
+        return f"{float(value):.2f}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _add_ticker_to_dashboard(symbol: str) -> None:
+    """Append ``symbol`` to the sidebar tickers input (session state)."""
+    symbol = symbol.strip().upper()
+    if not symbol:
+        return
+    current = st.session_state.get("tickers_str", "SPY") or ""
+    existing = [t.strip().upper() for t in current.split(",") if t.strip()]
+    if symbol not in existing:
+        existing.append(symbol)
+    st.session_state["tickers_str"] = ", ".join(existing)
+    st.session_state["_tickers_flash"] = symbol
+
+
+def _render_tickers_page() -> None:
+    """Seeking Alpha–style sector → industry → ticker browser."""
+    from julia import tickers_store
+
+    flash = st.session_state.pop("_tickers_flash", None)
+    if flash:
+        st.success(
+            f"Added **{flash}** to the dashboard ticker list — "
+            "switch to **OI Dashboard** to analyze it."
+        )
+
+    st.header("Tickers")
+    st.caption(
+        "Robinhood-tradable equities and funds, grouped the way Seeking Alpha "
+        "does — **sector → industry → symbol**. Data comes from Robinhood's "
+        "public instruments + fundamentals catalogs (no login) and is cached "
+        "in `.options_cache/tickers.db`. Click a symbol to add it to the "
+        "OI Dashboard ticker list."
+    )
+
+    n = tickers_store.ticker_count()
+    synced = tickers_store.get_meta("last_synced_at") or "never"
+
+    top_l, top_r = st.columns([3, 1])
+    with top_l:
+        st.metric("Tradable symbols cached", f"{n:,}")
+        st.caption(f"Last synced (UTC): {synced}")
+    with top_r:
+        if st.button(
+            "🔄 Sync from Robinhood",
+            use_container_width=True,
+            help="Re-download the full tradable universe (~2–4 minutes).",
+        ):
+            progress = st.progress(0.0, text="Starting sync…")
+            status = st.empty()
+
+            def _cb(stage: str, a: int, b: int) -> None:
+                frac = (a / b) if b else 0.0
+                # Instruments ~40% of the bar, fundamentals the rest.
+                if stage == "instruments":
+                    progress.progress(
+                        min(0.4, 0.4 * frac),
+                        text=f"Instruments… page {a}",
+                    )
+                else:
+                    progress.progress(
+                        0.4 + 0.6 * frac,
+                        text=f"Fundamentals… batch {a}/{b}",
+                    )
+                status.caption(f"{stage}: {a}/{b}")
+
+            with st.spinner("Syncing Robinhood tradable tickers…"):
+                stats = tickers_store.sync_tradable_tickers(progress=_cb)
+            progress.progress(1.0, text="Done")
+            st.success(
+                f"Synced {stats['instruments']:,} symbols "
+                f"({stats['with_sector']:,} with sector) at {stats['synced_at']}"
+            )
+            st.rerun()
+
+    if n == 0:
+        st.warning(
+            "No ticker cache yet. Click **Sync from Robinhood** above "
+            "(or run `lia tickers-sync`) to populate sector / industry lists."
+        )
+        return
+
+    # Filters row
+    f1, f2, f3 = st.columns([2, 2, 3])
+    with f1:
+        universe = st.selectbox(
+            "Universe",
+            ["All", "Stocks", "ETFs & funds"],
+            key="tickers_universe",
+            help=(
+                "Stocks = common shares, ADRs, REITs, MLPs. "
+                "ETFs & funds = ETPs and closed-end funds."
+            ),
+        )
+    with f2:
+        search = st.text_input(
+            "Search symbol or name",
+            key="tickers_search",
+            placeholder="e.g. AAPL or Nvidia",
+        )
+    with f3:
+        st.write("")  # spacer
+        st.caption(
+            "Tip: pick a sector on the left, then an industry, then add "
+            "symbols to the dashboard."
+        )
+
+    type_filter = None
+    if universe == "Stocks":
+        type_filter = ["stock", "adr", "reit", "mlp", "lp"]
+    elif universe == "ETFs & funds":
+        type_filter = ["etp", "cef", "tracking"]
+
+    # When searching, show a flat hit list and skip the sector tree.
+    if search and search.strip():
+        hits = tickers_store.list_tickers(
+            search=search.strip(),
+            instrument_types=type_filter,
+            limit=500,
+        )
+        st.subheader(f"Search results · {len(hits):,} match(es)")
+        _render_tickers_table(hits)
+        return
+
+    left, right = st.columns([1, 3], gap="large")
+
+    sectors = tickers_store.list_sectors(instrument_types=type_filter)
+
+    if "tickers_selected_sector" not in st.session_state and sectors:
+        st.session_state["tickers_selected_sector"] = sectors[0]["sector"]
+    if "tickers_selected_industry" not in st.session_state:
+        st.session_state["tickers_selected_industry"] = None
+
+    # If the active sector vanished under the current filter, reset.
+    sector_names = {s["sector"] for s in sectors}
+    if st.session_state.get("tickers_selected_sector") not in sector_names:
+        st.session_state["tickers_selected_sector"] = (
+            sectors[0]["sector"] if sectors else None
+        )
+        st.session_state["tickers_selected_industry"] = None
+
+    with left:
+        st.markdown("##### Sectors")
+        for sec in sectors:
+            label = f"{sec['sector']}  ({sec['count']:,})"
+            is_active = (
+                st.session_state.get("tickers_selected_sector") == sec["sector"]
+            )
+            if st.button(
+                label,
+                key=f"sec_{sec['sector']}",
+                use_container_width=True,
+                type="primary" if is_active else "secondary",
+            ):
+                st.session_state["tickers_selected_sector"] = sec["sector"]
+                st.session_state["tickers_selected_industry"] = None
+                st.rerun()
+
+    selected_sector = st.session_state.get("tickers_selected_sector")
+    with right:
+        if not selected_sector:
+            st.info("Select a sector to browse industries.")
+            return
+
+        st.markdown(f"### {selected_sector}")
+        industries = tickers_store.list_industries(
+            selected_sector, instrument_types=type_filter
+        )
+
+        st.markdown("##### Industries")
+        if not industries:
+            st.caption("No industries in this sector for the current filter.")
+            return
+
+        selected_industry = st.session_state.get("tickers_selected_industry")
+        ind_names = {i["industry"] for i in industries}
+        if selected_industry not in ind_names:
+            selected_industry = industries[0]["industry"]
+            st.session_state["tickers_selected_industry"] = selected_industry
+
+        cols_per_row = 3
+        for i in range(0, len(industries), cols_per_row):
+            cols = st.columns(cols_per_row)
+            for col, ind in zip(cols, industries[i : i + cols_per_row]):
+                active = selected_industry == ind["industry"]
+                with col:
+                    if st.button(
+                        f"{ind['industry']} ({ind['count']:,})",
+                        key=f"ind_{selected_sector}_{ind['industry']}",
+                        use_container_width=True,
+                        type="primary" if active else "secondary",
+                    ):
+                        st.session_state["tickers_selected_industry"] = ind[
+                            "industry"
+                        ]
+                        st.rerun()
+
+        st.divider()
+        st.markdown(
+            f"##### {selected_industry} "
+            f"<span style='font-weight:400;color:#888'>in {selected_sector}</span>",
+            unsafe_allow_html=True,
+        )
+        rows = tickers_store.list_tickers(
+            sector=selected_sector,
+            industry=selected_industry,
+            instrument_types=type_filter,
+            limit=5000,
+        )
+        st.caption(f"{len(rows):,} tickers · sorted by market cap")
+        _render_tickers_table(rows)
+
+
+def _render_tickers_table(rows: list[dict]) -> None:
+    """Interactive table + one-click add-to-dashboard for the current list."""
+    if not rows:
+        st.info("No tickers match these filters.")
+        return
+
+    display = pd.DataFrame(
+        [
+            {
+                "Symbol": r["symbol"],
+                "Name": r.get("simple_name") or r.get("name") or "",
+                "Type": (r.get("instrument_type") or "").upper(),
+                "Sector": r.get("sector") or "—",
+                "Industry": r.get("industry") or "—",
+                "Market Cap": _fmt_market_cap(r.get("market_cap")),
+                "P/E": _fmt_ratio(r.get("pe_ratio")),
+                "Div Yield %": _fmt_ratio(r.get("dividend_yield")),
+            }
+            for r in rows
+        ]
+    )
+    st.dataframe(
+        display,
+        use_container_width=True,
+        hide_index=True,
+        height=min(560, 40 + 35 * min(len(display), 15)),
+    )
+
+    add_cols = st.columns([3, 1])
+    with add_cols[0]:
+        pick = st.selectbox(
+            "Add to OI Dashboard",
+            options=[r["symbol"] for r in rows],
+            key=f"tickers_add_pick_{rows[0]['symbol']}_{len(rows)}",
+        )
+    with add_cols[1]:
+        st.write("")
+        if st.button("➕ Add ticker", use_container_width=True, type="primary"):
+            _add_ticker_to_dashboard(pick)
+            st.rerun()
+
+
+# ---------------------------------------------------------------------------
 # Main app
 # ---------------------------------------------------------------------------
 
@@ -4870,6 +5155,14 @@ st.set_page_config(page_title="Options OI Dashboard", layout="wide")
 st.title("📊 Options OI — Live Dashboard")
 _git_sha, _git_when = _running_git_revision()
 st.caption(f"Running `{_git_sha}` · committed {_git_when}")
+
+_page = st.radio(
+    "Navigate",
+    ["OI Dashboard", "Tickers"],
+    horizontal=True,
+    key="top_nav",
+    label_visibility="collapsed",
+)
 
 with st.sidebar:
     st.header("Config")
@@ -4910,9 +5203,13 @@ with st.sidebar:
 
     st.divider()
     st.subheader("Refresh")
-    auto = st.toggle("Auto-refresh every 5s", value=True, key="auto")
-    if auto:
-        st_autorefresh(interval=5_000, key="_autoref")
+    if _page == "OI Dashboard":
+        auto = st.toggle("Auto-refresh every 5s", value=True, key="auto")
+        if auto:
+            st_autorefresh(interval=5_000, key="_autoref")
+    else:
+        auto = False
+        st.caption("Auto-refresh is paused on the Tickers tab.")
 
     col_r1, col_r2 = st.columns(2)
     with col_r1:
@@ -4931,6 +5228,9 @@ with st.sidebar:
             _kickoff_batch(tickers, start, end, refresh_cache)
             st.rerun()
 
+if _page == "Tickers":
+    _render_tickers_page()
+    st.stop()
 
 start, end, exps = _compute_range(days_ahead)
 

--- a/scripts/oi_dashboard_app.py
+++ b/scripts/oi_dashboard_app.py
@@ -4895,16 +4895,30 @@ def _fmt_ratio(value) -> str:
 
 
 def _add_ticker_to_dashboard(symbol: str) -> None:
-    """Append ``symbol`` to the sidebar tickers input (session state)."""
+    """Queue ``symbol`` to be merged into the sidebar tickers on the next run.
+
+    Streamlit forbids mutating ``st.session_state[key]`` after a widget with
+    that ``key`` has already been instantiated in the same script run, so we
+    stash the symbol and apply it *before* the sidebar ``text_input`` on the
+    subsequent rerun.
+    """
     symbol = symbol.strip().upper()
+    if not symbol:
+        return
+    st.session_state["_pending_ticker_add"] = symbol
+    st.session_state["_tickers_flash"] = symbol
+
+
+def _apply_pending_ticker_add() -> None:
+    """Merge any queued ticker into ``tickers_str`` before the widget is built."""
+    symbol = st.session_state.pop("_pending_ticker_add", None)
     if not symbol:
         return
     current = st.session_state.get("tickers_str", "SPY") or ""
     existing = [t.strip().upper() for t in current.split(",") if t.strip()]
     if symbol not in existing:
         existing.append(symbol)
-    st.session_state["tickers_str"] = ", ".join(existing)
-    st.session_state["_tickers_flash"] = symbol
+    st.session_state["tickers_str"] = ", ".join(existing) or "SPY"
 
 
 def _render_tickers_page() -> None:
@@ -5095,13 +5109,27 @@ def _render_tickers_page() -> None:
             f"<span style='font-weight:400;color:#888'>in {selected_sector}</span>",
             unsafe_allow_html=True,
         )
+        industry_total = next(
+            (
+                i["count"]
+                for i in industries
+                if i["industry"] == selected_industry
+            ),
+            None,
+        )
         rows = tickers_store.list_tickers(
             sector=selected_sector,
             industry=selected_industry,
             instrument_types=type_filter,
             limit=5000,
         )
-        st.caption(f"{len(rows):,} tickers · sorted by market cap")
+        if industry_total and industry_total > len(rows):
+            st.caption(
+                f"Showing {len(rows):,} of {industry_total:,} tickers "
+                f"· sorted by market cap (top by market cap)"
+            )
+        else:
+            st.caption(f"{len(rows):,} tickers · sorted by market cap")
         _render_tickers_table(rows)
 
 
@@ -5155,6 +5183,8 @@ st.set_page_config(page_title="Options OI Dashboard", layout="wide")
 st.title("📊 Options OI — Live Dashboard")
 _git_sha, _git_when = _running_git_revision()
 st.caption(f"Running `{_git_sha}` · committed {_git_when}")
+
+_apply_pending_ticker_add()
 
 _page = st.radio(
     "Navigate",

--- a/src/julia/main.py
+++ b/src/julia/main.py
@@ -2791,6 +2791,34 @@ def cache(stats, list_cache, clear_all, clear_expired, clear_ticker):
         click.echo(f"  --clear-all      Remove all cached data")
 
 
+@cli.command("tickers-sync")
+@click.option(
+    "--quiet",
+    is_flag=True,
+    help="Only print the final summary line",
+)
+def tickers_sync(quiet):
+    """Refresh the Robinhood tradable-ticker sector/industry cache.
+
+    Pulls the public instruments + fundamentals catalogs (no login) and
+    writes ``.options_cache/tickers.db`` for the dashboard Tickers tab.
+    """
+    from julia.tickers_store import sync_tradable_tickers
+
+    def _progress(stage: str, a: int, b: int) -> None:
+        if quiet:
+            return
+        click.echo(f"  {stage}: {a}/{b}")
+
+    if not quiet:
+        click.echo("Syncing Robinhood tradable tickers (sector/industry)…")
+    stats = sync_tradable_tickers(progress=_progress)
+    click.echo(
+        f"✅ {stats['instruments']} tradable symbols "
+        f"({stats['with_sector']} with sector) · synced {stats['synced_at']}"
+    )
+
+
 def main():
     # Example usage:
     stock_price = 590

--- a/src/julia/tickers_store.py
+++ b/src/julia/tickers_store.py
@@ -1,0 +1,422 @@
+"""SQLite cache of Robinhood-tradable tickers grouped by sector / industry.
+
+Pulls the public instruments catalog (``/instruments/``) and fundamentals
+(``/fundamentals/``) — no Robinhood login required — and stores every
+currently tradable symbol with its Seeking Alpha–style sector / industry
+labels for the dashboard Tickers tab.
+
+Cache lives at ``.options_cache/tickers.db`` (alongside the predictions DB).
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable, Optional
+
+import requests
+
+DEFAULT_DB_PATH = os.path.join(".options_cache", "tickers.db")
+
+INSTRUMENTS_URL = "https://api.robinhood.com/instruments/"
+FUNDAMENTALS_URL = "https://api.robinhood.com/fundamentals/"
+USER_AGENT = "julia-dashboard/0.1 (+https://github.com/tekneeq/julia)"
+
+# Fundamentals ``symbols=`` query; RH accepts ~100 but 50 is safer.
+FUNDAMENTALS_BATCH = 50
+
+# Equity-like types we surface in the sector browser. Warrants / rights /
+# preferreds stay out of the Seeking Alpha–style equity tree.
+EQUITY_TYPES = frozenset(
+    {"stock", "adr", "etp", "reit", "cef", "mlp", "lp", "tracking"}
+)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS meta (
+    key   TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS tickers (
+    symbol       TEXT PRIMARY KEY,
+    name         TEXT,
+    simple_name  TEXT,
+    instrument_type TEXT,
+    country      TEXT,
+    list_date    TEXT,
+    tradeable    INTEGER NOT NULL DEFAULT 1,
+    sector       TEXT,
+    industry     TEXT,
+    market_cap   REAL,
+    pe_ratio     REAL,
+    dividend_yield REAL,
+    description  TEXT,
+    updated_at   TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tickers_sector
+    ON tickers(sector, industry, symbol);
+
+CREATE INDEX IF NOT EXISTS idx_tickers_industry
+    ON tickers(industry, symbol);
+
+CREATE INDEX IF NOT EXISTS idx_tickers_type
+    ON tickers(instrument_type);
+"""
+
+
+ProgressCb = Callable[[str, int, int], None]
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _session() -> requests.Session:
+    s = requests.Session()
+    s.headers.update(
+        {
+            "Accept": "application/json",
+            "User-Agent": USER_AGENT,
+        }
+    )
+    return s
+
+
+@contextmanager
+def _connect(db_path: str = DEFAULT_DB_PATH):
+    parent = os.path.dirname(db_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.executescript(_SCHEMA)
+        yield conn
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _set_meta(conn: sqlite3.Connection, key: str, value: str) -> None:
+    conn.execute(
+        "INSERT INTO meta(key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, value),
+    )
+
+
+def get_meta(key: str, db_path: str = DEFAULT_DB_PATH) -> Optional[str]:
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            "SELECT value FROM meta WHERE key = ?", (key,)
+        ).fetchone()
+    return row["value"] if row else None
+
+
+def ticker_count(db_path: str = DEFAULT_DB_PATH) -> int:
+    with _connect(db_path) as conn:
+        row = conn.execute("SELECT COUNT(*) AS n FROM tickers").fetchone()
+    return int(row["n"]) if row else 0
+
+
+def _is_tradable(inst: dict[str, Any]) -> bool:
+    """Active equity the Robinhood app will let you open a new position in."""
+    return (
+        bool(inst.get("symbol"))
+        and inst.get("state") == "active"
+        and inst.get("tradeable") is True
+        and inst.get("tradability") == "tradable"
+        and inst.get("rhs_tradability") == "tradable"
+    )
+
+
+def _fetch_all_instruments(
+    session: requests.Session,
+    progress: Optional[ProgressCb] = None,
+) -> list[dict[str, Any]]:
+    """Paginate Robinhood instruments; return active RH-tradable rows."""
+    url: Optional[str] = INSTRUMENTS_URL
+    params: Optional[dict[str, str]] = {"active_instruments_only": "true"}
+    out: list[dict[str, Any]] = []
+    pages = 0
+    while url:
+        resp = session.get(url, params=params, timeout=60)
+        resp.raise_for_status()
+        payload = resp.json()
+        params = None  # cursor is embedded in ``next``
+        pages += 1
+        for inst in payload.get("results") or []:
+            if not _is_tradable(inst):
+                continue
+            itype = (inst.get("type") or "unknown").lower()
+            if itype not in EQUITY_TYPES:
+                continue
+            out.append(inst)
+        if progress and pages % 10 == 0:
+            progress("instruments", pages, len(out))
+        url = payload.get("next")
+    if progress:
+        progress("instruments", pages, len(out))
+    return out
+
+
+def _fetch_fundamentals_batch(
+    session: requests.Session, symbols: list[str]
+) -> list[Optional[dict[str, Any]]]:
+    """Return fundamentals aligned 1:1 with ``symbols`` (None on miss)."""
+    if not symbols:
+        return []
+    resp = session.get(
+        FUNDAMENTALS_URL,
+        params={"symbols": ",".join(symbols)},
+        timeout=60,
+    )
+    resp.raise_for_status()
+    results = resp.json().get("results") or []
+    # Pad / trim to match request length; RH returns nulls for unknowns.
+    out: list[Optional[dict[str, Any]]] = []
+    for i, sym in enumerate(symbols):
+        item = results[i] if i < len(results) else None
+        if item is None:
+            out.append(None)
+            continue
+        item = dict(item)
+        item["symbol"] = sym
+        out.append(item)
+    return out
+
+
+def _fnum(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def sync_tradable_tickers(
+    *,
+    db_path: str = DEFAULT_DB_PATH,
+    progress: Optional[ProgressCb] = None,
+    sleep_s: float = 0.05,
+) -> dict[str, Any]:
+    """Full refresh of the tradable-ticker cache from Robinhood public APIs.
+
+    Returns a small stats dict: ``{"instruments": N, "with_sector": M, ...}``.
+    """
+    session = _session()
+    instruments = _fetch_all_instruments(session, progress=progress)
+    symbols = [i["symbol"].upper() for i in instruments]
+    by_symbol = {i["symbol"].upper(): i for i in instruments}
+
+    fundamentals: dict[str, dict[str, Any]] = {}
+    total_batches = (len(symbols) + FUNDAMENTALS_BATCH - 1) // FUNDAMENTALS_BATCH
+    for bi in range(total_batches):
+        chunk = symbols[bi * FUNDAMENTALS_BATCH : (bi + 1) * FUNDAMENTALS_BATCH]
+        try:
+            batch = _fetch_fundamentals_batch(session, chunk)
+        except requests.RequestException:
+            # One failed batch shouldn't kill the whole sync — leave sector blank.
+            batch = [None] * len(chunk)
+        for item in batch:
+            if item and item.get("symbol"):
+                fundamentals[item["symbol"].upper()] = item
+        if progress:
+            progress("fundamentals", bi + 1, total_batches)
+        if sleep_s:
+            time.sleep(sleep_s)
+
+    now = _now_iso()
+    rows = []
+    with_sector = 0
+    for sym in symbols:
+        inst = by_symbol[sym]
+        fund = fundamentals.get(sym) or {}
+        sector = (fund.get("sector") or "").strip() or None
+        industry = (fund.get("industry") or "").strip() or None
+        if sector:
+            with_sector += 1
+        rows.append(
+            (
+                sym,
+                inst.get("name"),
+                inst.get("simple_name"),
+                (inst.get("type") or "unknown").lower(),
+                inst.get("country"),
+                inst.get("list_date"),
+                1,
+                sector,
+                industry,
+                _fnum(fund.get("market_cap")),
+                _fnum(fund.get("pe_ratio")),
+                _fnum(fund.get("dividend_yield")),
+                fund.get("description"),
+                now,
+            )
+        )
+
+    with _connect(db_path) as conn:
+        conn.execute("DELETE FROM tickers")
+        conn.executemany(
+            """
+            INSERT INTO tickers (
+                symbol, name, simple_name, instrument_type, country, list_date,
+                tradeable, sector, industry, market_cap, pe_ratio,
+                dividend_yield, description, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            rows,
+        )
+        _set_meta(conn, "last_synced_at", now)
+        _set_meta(conn, "instrument_count", str(len(rows)))
+
+    return {
+        "instruments": len(rows),
+        "with_sector": with_sector,
+        "synced_at": now,
+    }
+
+
+def list_sectors(
+    db_path: str = DEFAULT_DB_PATH,
+    instrument_types: Optional[Iterable[str]] = None,
+) -> list[dict[str, Any]]:
+    """Sector → ticker count, Seeking Alpha–style overview."""
+    clauses = ["1=1"]
+    params: list[Any] = []
+    if instrument_types:
+        types = [t.lower() for t in instrument_types]
+        placeholders = ",".join("?" for _ in types)
+        clauses.append(f"instrument_type IN ({placeholders})")
+        params.extend(types)
+    where = " AND ".join(clauses)
+    with _connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT COALESCE(NULLIF(sector, ''), 'Unclassified') AS sector,
+                   COUNT(*) AS n
+            FROM tickers
+            WHERE {where}
+            GROUP BY 1
+            ORDER BY n DESC, sector ASC
+            """,
+            params,
+        ).fetchall()
+    return [{"sector": r["sector"], "count": int(r["n"])} for r in rows]
+
+
+def list_industries(
+    sector: str,
+    db_path: str = DEFAULT_DB_PATH,
+    instrument_types: Optional[Iterable[str]] = None,
+) -> list[dict[str, Any]]:
+    """Industries under a sector with counts."""
+    unclassified = sector == "Unclassified"
+    clauses: list[str] = []
+    params: list[Any] = []
+    if unclassified:
+        clauses.append("(sector IS NULL OR TRIM(sector) = '')")
+    else:
+        clauses.append("sector = ?")
+        params.append(sector)
+    if instrument_types:
+        types = [t.lower() for t in instrument_types]
+        placeholders = ",".join("?" for _ in types)
+        clauses.append(f"instrument_type IN ({placeholders})")
+        params.extend(types)
+    where = " AND ".join(clauses)
+    with _connect(db_path) as conn:
+        rows = conn.execute(
+            f"""
+            SELECT COALESCE(NULLIF(industry, ''), 'Unclassified') AS industry,
+                   COUNT(*) AS n
+            FROM tickers
+            WHERE {where}
+            GROUP BY 1
+            ORDER BY n DESC, industry ASC
+            """,
+            params,
+        ).fetchall()
+    return [{"industry": r["industry"], "count": int(r["n"])} for r in rows]
+
+
+def list_tickers(
+    *,
+    sector: Optional[str] = None,
+    industry: Optional[str] = None,
+    search: Optional[str] = None,
+    instrument_types: Optional[Iterable[str]] = None,
+    limit: int = 5000,
+    db_path: str = DEFAULT_DB_PATH,
+) -> list[dict[str, Any]]:
+    """Filter the cached universe for the Tickers table."""
+    clauses: list[str] = ["1=1"]
+    params: list[Any] = []
+
+    if sector == "Unclassified":
+        clauses.append("(sector IS NULL OR TRIM(sector) = '')")
+    elif sector:
+        clauses.append("sector = ?")
+        params.append(sector)
+
+    if industry == "Unclassified":
+        clauses.append("(industry IS NULL OR TRIM(industry) = '')")
+    elif industry:
+        clauses.append("industry = ?")
+        params.append(industry)
+
+    if search:
+        q = f"%{search.strip().upper()}%"
+        clauses.append(
+            "(UPPER(symbol) LIKE ? OR UPPER(COALESCE(name, '')) LIKE ? "
+            "OR UPPER(COALESCE(simple_name, '')) LIKE ?)"
+        )
+        params.extend([q, q, q])
+
+    if instrument_types:
+        types = [t.lower() for t in instrument_types]
+        placeholders = ",".join("?" for _ in types)
+        clauses.append(f"instrument_type IN ({placeholders})")
+        params.extend(types)
+
+    sql = f"""
+        SELECT symbol, name, simple_name, instrument_type, country,
+               sector, industry, market_cap, pe_ratio, dividend_yield,
+               list_date
+        FROM tickers
+        WHERE {' AND '.join(clauses)}
+        ORDER BY
+            CASE WHEN market_cap IS NULL THEN 1 ELSE 0 END,
+            market_cap DESC,
+            symbol ASC
+        LIMIT ?
+    """
+    params.append(int(limit))
+
+    with _connect(db_path) as conn:
+        rows = conn.execute(sql, params).fetchall()
+    return [dict(r) for r in rows]
+
+
+def sector_industry_tree(
+    db_path: str = DEFAULT_DB_PATH,
+    instrument_types: Optional[Iterable[str]] = None,
+) -> list[dict[str, Any]]:
+    """Nested sector → industries structure for the left-nav browser."""
+    tree: list[dict[str, Any]] = []
+    for sec in list_sectors(db_path, instrument_types=instrument_types):
+        industries = list_industries(
+            sec["sector"], db_path=db_path, instrument_types=instrument_types
+        )
+        tree.append(
+            {
+                "sector": sec["sector"],
+                "count": sec["count"],
+                "industries": industries,
+            }
+        )
+    return tree


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a top-level **Tickers** tab to the Streamlit OI dashboard that browses every Robinhood-tradable equity/fund in a Seeking Alpha–style **sector → industry → symbol** hierarchy.

## What’s included
- New SQLite cache (`.options_cache/tickers.db`) populated from Robinhood’s public instruments + fundamentals APIs (no login)
- `lia tickers-sync` CLI to refresh the universe (~12k tradable symbols)
- Dashboard top nav: **OI Dashboard** | **Tickers**
- Filters for All / Stocks / ETFs & funds, symbol/name search, and one-click add to the sidebar ticker list
- Auto-refresh is paused while browsing Tickers so the sector tree doesn’t reset

## How to use
1. Open the dashboard and select **Tickers**
2. Click **Sync from Robinhood** (or run `lia tickers-sync`) if the cache is empty
3. Pick a sector → industry, then **Add ticker** to analyze it on the OI Dashboard

## Tested
- Synced 12,376 tradable symbols with sector/industry metadata
- Manually verified Stocks → Electronic Technology → Telecommunications Equipment → add AAPL to dashboard

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d14d871e-e61a-48e6-8a7e-0feacc5779a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d14d871e-e61a-48e6-8a7e-0feacc5779a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

