### PR TITLE
Add Discord stock bot and fold it into deploy

### DIFF
--- a/.github/workflows/deploy-ec2.yml
+++ b/.github/workflows/deploy-ec2.yml
@@ -48,5 +48,5 @@ jobs:
             # restart.sh already git-pulls, but pull first so deploy.sh
             # itself is up to date before we execute it.
             git pull --ff-only origin main
-            chmod +x deploy.sh restart.sh restart-oi-scheduler.sh restart-price-poller.sh
+            chmod +x deploy.sh restart.sh restart-oi-scheduler.sh restart-price-poller.sh restart-discord-bot.sh
             ./deploy.sh

--- a/README.md
+++ b/README.md
@@ -137,6 +137,31 @@ RH_PASSWORD=your_password
 
 **Note**: The `.env` file is automatically ignored by git for security.
 
+### Discord stock bot (optional)
+
+Create a **new** Discord application at https://discord.com/developers/applications
+(do not reuse another bot's token), enable **Message Content Intent**, invite the
+bot to your server, then add to `.env`:
+
+```bash
+DISCORD_BOT_TOKEN=...          # required to start the bot
+DISCORD_CHANNEL_ID=...         # optional — channel for the ready greeting
+```
+
+On the julia EC2 host, `./deploy.sh` starts the bot inside the dashboard
+container (same lifecycle as the price poller). If `DISCORD_BOT_TOKEN` is
+unset, deploy skips the bot and continues.
+
+```bash
+./restart-discord-bot.sh           # start / restart
+./restart-discord-bot.sh --status
+./restart-discord-bot.sh --logs
+./restart-discord-bot.sh --stop
+```
+
+In Discord: `!help`, `!price AAPL`, `!quote SPY`, `!info MSFT`, `!sectors`,
+`!industries Technology Services`, `!tickers Finance`, `!search nvidia`.
+
 ## Usage
 
 ### Programmatic Usage

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 #
 # Pull latest code, rebuild the dashboard container, then re-attach the
-# detached in-container services (OI scheduler + price poller).
+# detached in-container services (OI scheduler + price poller + Discord bot).
 #
 # Order matters: ``restart.sh`` replaces the container, which kills any
-# ``docker exec -d`` processes — so the scheduler and poller must be
-# started *after* the container comes back up.
+# ``docker exec -d`` processes — so the scheduler, poller, and Discord bot
+# must be started *after* the container comes back up.
 #
 # Usage (on the EC2 host, from the repo root):
 #   ./deploy.sh
@@ -22,7 +22,7 @@ log() { echo "[$(ts)] $*"; }
 
 log "=== deploy start (cwd=$(pwd), rev=$(git rev-parse --short HEAD 2>/dev/null || echo '?')) ==="
 
-log "1/4  rebuild dashboard container (git pull + docker build/run)"
+log "1/5  rebuild dashboard container (git pull + docker build/run)"
 ./restart.sh
 
 # Give Streamlit a moment to bind :8501 before we pile on more processes.
@@ -37,15 +37,18 @@ fi
 # They are usually root-owned (written inside the container), so delete
 # via docker exec rather than host ``rm`` (which Permission-denies).
 docker exec julia-dashboard rm -f \
-    logs/oi-scheduler.pid logs/price-poller.pid
+    logs/oi-scheduler.pid logs/price-poller.pid logs/discord-bot.pid
 
-log "2/4  restart OI scheduler (detached)"
+log "2/5  restart OI scheduler (detached)"
 ./restart-oi-scheduler.sh
 
-log "3/4  restart price poller (detached)"
+log "3/5  restart price poller (detached)"
 ./restart-price-poller.sh
 
-log "4/4  one-off batch to seed the current expiration window"
+log "4/5  restart Discord stock bot (skipped if DISCORD_BOT_TOKEN unset)"
+./restart-discord-bot.sh
+
+log "5/5  one-off batch to seed the current expiration window"
 # Blocks until the batch finishes so 08-17 / 08-18 etc. get a snapshot
 # immediately instead of waiting for the next :00/:30 slot.
 ./restart-oi-scheduler.sh --run-once
@@ -53,3 +56,4 @@ log "4/4  one-off batch to seed the current expiration window"
 log "=== deploy done (rev=$(git rev-parse --short HEAD)) ==="
 ./restart-oi-scheduler.sh --status || true
 ./restart-price-poller.sh --status || true
+./restart-discord-bot.sh --status || true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 ]
 dependencies = [
     "click>=8.1.8",
+    "discord>=2.3.2",
     "markupsafe==3.0.2",
     "matplotlib>=3.11.0",
     "numpy>=2.0.2",
@@ -61,9 +62,8 @@ audio = [
     "pydub>=0.25.1",
     "simpleaudio>=1.0.4",
 ]
-# discorder.py / redder.py — Discord + Reddit bot integrations.
+# discorder.py / redder.py — Reddit (Discord is a core dep for the stock bot).
 chat = [
-    "discord>=2.3.2",
     "praw>=7.8.1",
 ]
 # Convenience — pull everything in one go.
@@ -75,7 +75,6 @@ all = [
     "openai>=2.7.2",
     "pydub>=0.25.1",
     "simpleaudio>=1.0.4",
-    "discord>=2.3.2",
     "praw>=7.8.1",
 ]
 

--- a/restart-discord-bot.sh
+++ b/restart-discord-bot.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Restart (or inspect) the Julia Discord stock bot inside the dashboard
+# container. Answers !price / !quote / !info / !sectors / !search etc.
+#
+# The bot starts DETACHED, so it survives the shell that launched it.
+# Console output goes to logs/discord-bot.out on the host.
+#
+# Usage
+#   ./restart-discord-bot.sh                restart, detached
+#   ./restart-discord-bot.sh --status       is it up?
+#   ./restart-discord-bot.sh --stop         stop the bot
+#   ./restart-discord-bot.sh --logs         follow the bot console log
+#   ./restart-discord-bot.sh --foreground   run attached
+#
+# Requires DISCORD_BOT_TOKEN in the host .env (loaded into the container
+# via docker --env-file). If the token is missing, this script exits 0
+# with a skip message so ``deploy.sh`` can keep going on hosts that have
+# not configured Discord yet.
+#
+# Note: a detached `docker exec` does not survive a container restart, so
+# run this again after ./restart.sh or a host reboot (deploy.sh does).
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+CONTAINER="${OI_CONTAINER:-julia-dashboard}"
+BOT="scripts/discord_bot.py"
+OUT_LOG="logs/discord-bot.out"
+
+MODE="restart"
+FOREGROUND=0
+
+usage() { sed -n '2,/^[^#]/p' "$0" | sed 's/^#//; s/^ //' | sed '$d'; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -s|--status)        MODE="status"; shift ;;
+        --stop)             MODE="stop"; shift ;;
+        -l|--logs)          MODE="logs"; shift ;;
+        -f|--foreground)    FOREGROUND=1; shift ;;
+        -h|--help)          usage; exit 0 ;;
+        *)                  echo "Unknown arg: $1" >&2; usage; exit 2 ;;
+    esac
+done
+
+if ! docker ps --format '{{.Names}}' | grep -qx "$CONTAINER"; then
+    echo "❌ container '$CONTAINER' is not running. Start it with ./restart.sh" >&2
+    exit 1
+fi
+
+# Soft-skip when Discord isn't configured — don't fail deploy.
+TOKEN_SET="$(docker exec "$CONTAINER" sh -c \
+    'if [ -n "${DISCORD_BOT_TOKEN:-}" ]; then echo yes; else echo no; fi')"
+if [[ "$TOKEN_SET" != "yes" ]]; then
+    echo "⏭  DISCORD_BOT_TOKEN unset in container — skipping Discord bot."
+    echo "   Add DISCORD_BOT_TOKEN (and optional DISCORD_CHANNEL_ID) to .env,"
+    echo "   recreate the container (./restart.sh), then re-run $0."
+    exit 0
+fi
+
+TTY=()
+[ -t 0 ] && TTY=(-it)
+
+if [[ "$MODE" == "logs" ]]; then
+    exec docker exec "${TTY[@]+"${TTY[@]}"}" "$CONTAINER" \
+        tail -n 100 -f "$OUT_LOG"
+fi
+
+if [[ "$MODE" != "restart" ]]; then
+    exec docker exec "$CONTAINER" uv run python "$BOT" "--$MODE"
+fi
+
+if [[ $FOREGROUND -eq 1 ]]; then
+    exec docker exec "${TTY[@]+"${TTY[@]}"}" "$CONTAINER" \
+        uv run python "$BOT" --replace
+fi
+
+docker exec "$CONTAINER" rm -f logs/discord-bot.pid
+
+docker exec -d "$CONTAINER" sh -c \
+    "mkdir -p logs && setsid uv run python $BOT --replace >>$OUT_LOG 2>&1 </dev/null"
+
+sleep 5
+echo "── discord bot status ────────────────────────────────────────────"
+STATUS="$(docker exec "$CONTAINER" uv run python "$BOT" --status || true)"
+printf '%s\n' "$STATUS"
+echo
+echo "Console log: $OUT_LOG   (follow with: $0 --logs)"
+if ! printf '%s\n' "$STATUS" | grep -q 'Process: ● RUNNING'; then
+    echo "❌ discord bot failed to stay up — last log lines:" >&2
+    docker exec "$CONTAINER" sh -c "tail -n 60 $OUT_LOG" 2>/dev/null || true
+    exit 1
+fi

--- a/scripts/discord_bot.py
+++ b/scripts/discord_bot.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env -S uv run python
+"""Managed Discord stock-bot process for the julia EC2 host.
+
+Wraps ``julia.discorder`` with the same PID / --status / --stop / --replace
+lifecycle as ``price_poller.py`` so ``./restart-discord-bot.sh`` (and
+``deploy.sh``) can start it detached inside the dashboard container.
+
+Examples
+--------
+    ./scripts/discord_bot.py --status
+    ./scripts/discord_bot.py --replace
+    ./scripts/discord_bot.py --stop
+
+    # From the host (preferred):
+    ./restart-discord-bot.sh
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import signal
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PID_FILE = REPO_ROOT / "logs" / "discord-bot.pid"
+
+sys.path.insert(0, str(REPO_ROOT / "src"))
+
+_PID_MARKER = "discord_bot.py"
+
+
+# ---------------------------------------------------------------------------
+# PID file (same pattern as price_poller.py / oi_scheduler.py)
+# ---------------------------------------------------------------------------
+
+def _read_pid(pid_file: Path) -> int | None:
+    try:
+        return int(pid_file.read_text().strip())
+    except (OSError, ValueError):
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _pid_cmdline(pid: int) -> str:
+    try:
+        raw = Path(f"/proc/{pid}/cmdline").read_bytes()
+    except OSError:
+        return ""
+    return raw.replace(b"\x00", b" ").decode(errors="replace")
+
+
+def _is_our_process(pid: int) -> bool:
+    return _PID_MARKER in _pid_cmdline(pid)
+
+
+def _scrub_stale_pid(pid_file: Path) -> None:
+    pid = _read_pid(pid_file)
+    if pid is None or pid == os.getpid():
+        return
+    if not _pid_alive(pid) or not _is_our_process(pid):
+        pid_file.unlink(missing_ok=True)
+
+
+def _running_pid(pid_file: Path) -> int | None:
+    pid = _read_pid(pid_file)
+    if pid is None or pid == os.getpid() or not _pid_alive(pid):
+        return None
+    if not _is_our_process(pid):
+        return None
+    return pid
+
+
+def _write_pid(pid_file: Path) -> None:
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+    pid_file.write_text(f"{os.getpid()}\n")
+
+
+def _clear_pid(pid_file: Path) -> None:
+    if _read_pid(pid_file) == os.getpid():
+        pid_file.unlink(missing_ok=True)
+
+
+def _stop_running(pid_file: Path, timeout: float = 15.0) -> bool:
+    _scrub_stale_pid(pid_file)
+    pid = _running_pid(pid_file)
+    if pid is None:
+        return False
+    print(f"[{datetime.now():%H:%M:%S}] stopping discord bot pid {pid}…")
+    try:
+        os.kill(pid, signal.SIGTERM)
+    except OSError as e:
+        print(f"  couldn't signal pid {pid}: {e!r}")
+        return False
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _pid_alive(pid):
+            print(f"  pid {pid} exited.")
+            return True
+        time.sleep(0.25)
+    print(f"  pid {pid} still alive after {timeout:.0f}s — SIGKILL.")
+    try:
+        os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+    return True
+
+
+def _status_report(pid_file: Path) -> int:
+    now = datetime.now().astimezone()
+    print(f"discord-bot status  ·  {now:%a %Y-%m-%d %H:%M:%S}")
+    token = os.getenv("DISCORD_BOT_TOKEN")
+    print(f"Token:  {'set' if token else 'MISSING (set DISCORD_BOT_TOKEN in .env)'}")
+    channel = os.getenv("DISCORD_CHANNEL_ID")
+    print(f"Channel greeting: {channel or '(none)'}")
+    pid = _running_pid(pid_file)
+    if pid:
+        print(f"\nProcess: ● RUNNING (pid {pid}, pid-file {pid_file.name})")
+    else:
+        stale = _read_pid(pid_file)
+        extra = f" — stale pid-file points at {stale}" if stale else ""
+        print(f"\nProcess: ○ NOT RUNNING{extra}")
+        print("         start it with  ./restart-discord-bot.sh")
+    try:
+        from julia import tickers_store
+
+        n = tickers_store.ticker_count()
+        synced = tickers_store.get_meta("last_synced_at") or "never"
+        print(f"\nTicker cache: {n:,} symbols  ·  last synced {synced}")
+    except Exception as e:  # noqa: BLE001
+        print(f"\nTicker cache: unavailable ({e!r})")
+    return 0 if pid else 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    from dotenv import load_dotenv
+
+    load_dotenv()
+
+    p = argparse.ArgumentParser(
+        description="Julia Discord stock bot (PID-managed)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "--pid-file",
+        default=str(DEFAULT_PID_FILE),
+        help=f"PID file path (default: {DEFAULT_PID_FILE})",
+    )
+    p.add_argument(
+        "--replace",
+        action="store_true",
+        help="Stop any running bot before starting",
+    )
+    p.add_argument(
+        "--stop",
+        action="store_true",
+        help="Stop the running bot and exit",
+    )
+    p.add_argument(
+        "--status",
+        action="store_true",
+        help="Print running status and exit",
+    )
+    args = p.parse_args(argv)
+    pid_file = Path(args.pid_file)
+
+    if args.status:
+        return _status_report(pid_file)
+
+    if args.stop:
+        if not _stop_running(pid_file):
+            print(f"No discord bot running (pid-file {pid_file}).")
+        return 0
+
+    if not os.getenv("DISCORD_BOT_TOKEN"):
+        print(
+            "DISCORD_BOT_TOKEN is not set — refusing to start. "
+            "Add it to the host .env (see README).",
+            file=sys.stderr,
+        )
+        return 2
+
+    _scrub_stale_pid(pid_file)
+    if args.replace:
+        _stop_running(pid_file)
+    elif (existing := _running_pid(pid_file)) is not None:
+        print(
+            f"A discord bot is already running (pid {existing}). "
+            f"Use --replace to restart it, or --stop to shut it down.",
+            file=sys.stderr,
+        )
+        return 1
+
+    _write_pid(pid_file)
+
+    def _on_signal(signum, _frame):  # noqa: ANN001
+        print(f"[{datetime.now():%H:%M:%S}] got signal {signum}, shutting down…")
+        raise SystemExit(0)
+
+    signal.signal(signal.SIGTERM, _on_signal)
+    signal.signal(signal.SIGINT, _on_signal)
+
+    try:
+        from julia.discorder import run_bot
+
+        print(f"[{datetime.now():%H:%M:%S}] starting discord stock bot…")
+        run_bot()
+    finally:
+        _clear_pid(pid_file)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/julia/discorder.py
+++ b/src/julia/discorder.py
@@ -1,65 +1,434 @@
-# https://discord.com/developers/applications
+"""Julia Discord stock bot — query price, quote, sector/industry, search.
+
+Run via ``scripts/discord_bot.py`` (PID-managed) or:
+
+    uv run python -m julia.discorder
+
+Env (``.env`` on the julia EC2 host, loaded by docker ``--env-file``):
+
+    DISCORD_BOT_TOKEN      required — bot token from a *new* Discord app
+    DISCORD_CHANNEL_ID     optional — channel for the ready greeting
+    RH_USERNAME / RH_PASSWORD   for live ``!price`` / ``!quote``
+"""
+from __future__ import annotations
 
 import os
-import discord
-from discord import Intents
-from dotenv import load_dotenv
-import time
-import praw
+import traceback
+from typing import Any, Optional
 
+from dotenv import load_dotenv
 
 load_dotenv()
 
-TOKEN = os.getenv("DISCORD_BOT_TOKEN")
-CHANNEL_ID = int(os.getenv("DISCORD_CHANNEL_ID"))
-
-intents = Intents.default()
-intents.message_content = True
-client = discord.Client(intents=intents)
-
-
-###
-reddit = praw.Reddit(
-    client_id=os.getenv("REDDIT_CLIENT_ID"),
-    client_secret=os.getenv("REDDIT_CLIENT_SECRET"),
-    user_agent=f"redder:comment-scraper:v1.0 (by u/{os.getenv('REDDIT_USERNAME')})",
-    username=os.getenv("REDDIT_USERNAME"),
-    password=os.getenv("REDDIT_PASSWORD"),
-)
-
-username = "wsbapp"  # replace with any Reddit username
-user = reddit.redditor(username)
-
-submission_id = None
-latest_submission = None
-print(f"Latest threads by u/{username}:")
-for idx, submission in enumerate(user.submissions.new(limit=1)):
-
-    submission_id = submission.id
-    latest_submission = submission
-###
+# Discord is an optional install unless folded into core deps / --extra chat.
+try:
+    import discord
+    from discord import Intents
+except ImportError as e:  # pragma: no cover
+    raise SystemExit(
+        "discord package missing — install with "
+        "`uv sync --extra chat` or `pip install discord`"
+    ) from e
 
 
-@client.event
-async def on_ready():
-    channel = client.get_channel(CHANNEL_ID)
-    await channel.send("Hello from my bot! 🤖")
-    # await client.close()  # optional: exit after sending once
+HELP_TEXT = """**Julia stock bot**
+```
+!help                         this message
+!ping                         latency check
+!price  TICKER                latest Robinhood price
+!quote  TICKER                price + day change / volume
+!info   TICKER                sector, industry, market cap, P/E
+!sectors                      sector overview (counts)
+!industries <sector>          industries under a sector
+!tickers <sector> [industry]  top tickers by market cap
+!search <query>               symbol / name search
+```
+Universe is Robinhood-tradable symbols cached by `lia tickers-sync`.
+"""
 
 
-@client.event
-async def on_message(msg):
-    if msg.author.bot:
+def _fmt_market_cap(value: Any) -> str:
+    if value is None:
+        return "—"
+    try:
+        v = float(value)
+    except (TypeError, ValueError):
+        return "—"
+    abs_v = abs(v)
+    if abs_v >= 1e12:
+        return f"${v / 1e12:.2f}T"
+    if abs_v >= 1e9:
+        return f"${v / 1e9:.2f}B"
+    if abs_v >= 1e6:
+        return f"${v / 1e6:.2f}M"
+    return f"${v:,.0f}"
+
+
+def _fmt_num(value: Any, digits: int = 2) -> str:
+    if value is None or value == "":
+        return "—"
+    try:
+        return f"{float(value):,.{digits}f}"
+    except (TypeError, ValueError):
+        return "—"
+
+
+def _ensure_rh_login() -> bool:
+    try:
+        from julia.main import is_logged_in, login_robinhood
+
+        if is_logged_in():
+            return True
+        username = os.getenv("RH_USERNAME")
+        password = os.getenv("RH_PASSWORD")
+        if not username or not password:
+            return False
+        login_robinhood(username, password)
+        return is_logged_in()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _cmd_price(symbol: str) -> str:
+    if not _ensure_rh_login():
+        return "Robinhood login failed — check `RH_USERNAME` / `RH_PASSWORD`."
+    import robin_stocks.robinhood as rh
+
+    vals = rh.stocks.get_latest_price(
+        symbol, priceType=None, includeExtendedHours=True
+    )
+    if not vals or vals[0] is None:
+        return f"No price for **{symbol}**."
+    return f"**{symbol}** ${float(vals[0]):,.4f}".rstrip("0").rstrip(".")
+
+
+def _cmd_quote(symbol: str) -> str:
+    if not _ensure_rh_login():
+        return "Robinhood login failed — check `RH_USERNAME` / `RH_PASSWORD`."
+    import robin_stocks.robinhood as rh
+
+    quotes = rh.stocks.get_quotes(symbol)
+    if not quotes or not quotes[0]:
+        return f"No quote for **{symbol}**."
+    q = quotes[0]
+    last = float(q.get("last_trade_price") or 0)
+    prev = float(q.get("previous_close") or q.get("adjusted_previous_close") or 0)
+    ext = q.get("last_extended_hours_trade_price")
+    chg = (last - prev) if prev else None
+    pct = (chg / prev * 100.0) if prev and chg is not None else None
+    lines = [
+        f"**{symbol}** quote",
+        f"Last: `${last:,.4f}`".rstrip("0").rstrip("."),
+    ]
+    if prev:
+        sign = "+" if (chg or 0) >= 0 else ""
+        lines.append(
+            f"Prev close: `${prev:,.2f}`  ·  "
+            f"Change: `{sign}{_fmt_num(chg)}` (`{sign}{_fmt_num(pct)}%`)"
+        )
+    if ext:
+        lines.append(f"Extended: `${float(ext):,.4f}`")
+    if q.get("trading_halted") in (True, "true", "True"):
+        lines.append("⚠️ Trading halted")
+    return "\n".join(lines)
+
+
+def _lookup_cached(symbol: str) -> Optional[dict[str, Any]]:
+    try:
+        from julia import tickers_store
+
+        rows = tickers_store.list_tickers(search=symbol, limit=20)
+    except Exception:  # noqa: BLE001
+        return None
+    symbol = symbol.upper()
+    for row in rows:
+        if row.get("symbol") == symbol:
+            return row
+    return None
+
+
+def _cmd_info(symbol: str) -> str:
+    row = _lookup_cached(symbol)
+    fund: dict[str, Any] = {}
+    if _ensure_rh_login():
+        try:
+            import robin_stocks.robinhood as rh
+
+            data = rh.stocks.get_fundamentals(symbol)
+            if data and data[0]:
+                fund = data[0]
+        except Exception:  # noqa: BLE001
+            fund = {}
+
+    name = None
+    if row:
+        name = row.get("simple_name") or row.get("name")
+    sector = (fund.get("sector") or (row or {}).get("sector") or "—")
+    industry = (fund.get("industry") or (row or {}).get("industry") or "—")
+    mcap = fund.get("market_cap") or (row or {}).get("market_cap")
+    pe = fund.get("pe_ratio") or (row or {}).get("pe_ratio")
+    div = fund.get("dividend_yield") or (row or {}).get("dividend_yield")
+    desc = (fund.get("description") or (row or {}).get("description") or "")
+    itype = (row or {}).get("instrument_type") or ""
+
+    lines = [f"**{symbol}**" + (f" — {name}" if name else "")]
+    if itype:
+        lines.append(f"Type: `{itype.upper()}`")
+    lines.append(f"Sector: **{sector}**")
+    lines.append(f"Industry: **{industry}**")
+    lines.append(
+        f"Market cap: `{_fmt_market_cap(mcap)}`  ·  "
+        f"P/E: `{_fmt_num(pe)}`  ·  Div yield: `{_fmt_num(div)}%`"
+    )
+    if desc:
+        snippet = desc.strip().replace("\n", " ")
+        if len(snippet) > 280:
+            snippet = snippet[:277] + "…"
+        lines.append(snippet)
+    if not row and not fund:
+        lines.append(
+            "_No cache / fundamentals — run `lia tickers-sync` or check RH login._"
+        )
+    return "\n".join(lines)
+
+
+def _cmd_sectors() -> str:
+    from julia import tickers_store
+
+    n = tickers_store.ticker_count()
+    if n == 0:
+        return "Ticker cache empty — run `lia tickers-sync` (or Sync on the Tickers tab)."
+    rows = tickers_store.list_sectors()
+    lines = [f"**Sectors** ({n:,} tradable symbols)"]
+    for r in rows[:25]:
+        lines.append(f"• {r['sector']} — `{r['count']:,}`")
+    if len(rows) > 25:
+        lines.append(f"_…and {len(rows) - 25} more_")
+    return "\n".join(lines)
+
+
+def _cmd_industries(sector: str) -> str:
+    from julia import tickers_store
+
+    rows = tickers_store.list_industries(sector)
+    if not rows:
+        # Case-insensitive sector match
+        for s in tickers_store.list_sectors():
+            if s["sector"].lower() == sector.lower():
+                sector = s["sector"]
+                rows = tickers_store.list_industries(sector)
+                break
+    if not rows:
+        return (
+            f"No industries for sector `{sector}`. "
+            "Try `!sectors` for names."
+        )
+    lines = [f"**{sector}** industries"]
+    for r in rows:
+        lines.append(f"• {r['industry']} — `{r['count']:,}`")
+    return "\n".join(lines)
+
+
+def _cmd_tickers(sector: str, industry: Optional[str] = None) -> str:
+    from julia import tickers_store
+
+    # Fuzzy sector match
+    sectors = {s["sector"].lower(): s["sector"] for s in tickers_store.list_sectors()}
+    sector_key = sector.lower()
+    if sector_key in sectors:
+        sector = sectors[sector_key]
+    else:
+        matches = [name for low, name in sectors.items() if sector_key in low]
+        if len(matches) == 1:
+            sector = matches[0]
+        elif not matches:
+            return f"Unknown sector `{sector}`. Try `!sectors`."
+
+    if industry:
+        inds = {
+            i["industry"].lower(): i["industry"]
+            for i in tickers_store.list_industries(sector)
+        }
+        ind_key = industry.lower()
+        if ind_key in inds:
+            industry = inds[ind_key]
+        else:
+            matches = [name for low, name in inds.items() if ind_key in low]
+            if len(matches) == 1:
+                industry = matches[0]
+            elif not matches:
+                return (
+                    f"Unknown industry `{industry}` in **{sector}**. "
+                    f"Try `!industries {sector}`."
+                )
+
+    rows = tickers_store.list_tickers(
+        sector=sector, industry=industry, limit=15
+    )
+    if not rows:
+        return "No tickers matched."
+    title = f"**{industry}** in {sector}" if industry else f"**{sector}**"
+    lines = [f"{title} — top by market cap"]
+    for r in rows:
+        name = r.get("simple_name") or r.get("name") or ""
+        lines.append(
+            f"`{r['symbol']:<6}` {_fmt_market_cap(r.get('market_cap'))}"
+            + (f"  {name}" if name else "")
+        )
+    return "\n".join(lines)
+
+
+def _cmd_search(query: str) -> str:
+    from julia import tickers_store
+
+    rows = tickers_store.list_tickers(search=query, limit=15)
+    if not rows:
+        return f"No matches for `{query}`."
+    lines = [f"**Search** `{query}`"]
+    for r in rows:
+        name = r.get("simple_name") or r.get("name") or ""
+        sector = r.get("sector") or "—"
+        lines.append(
+            f"`{r['symbol']:<6}` {name}  ·  {sector}  ·  "
+            f"{_fmt_market_cap(r.get('market_cap'))}"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(content: str, command: str) -> list[str]:
+    rest = content[len(command) :].strip()
+    if not rest:
+        return []
+    return rest.split()
+
+
+async def _handle_message(msg: discord.Message) -> None:
+    content = (msg.content or "").strip()
+    if not content.startswith("!"):
         return
-    if msg.content == "!ping":
-        await msg.reply("pong!")
 
-    if "!rpost" in msg.content:
-        message = msg.content.split("!rpost")[1].strip()
+    lower = content.lower()
+    try:
+        if lower == "!ping":
+            await msg.reply("pong!")
+            return
+        if lower in ("!help", "!commands"):
+            await msg.reply(HELP_TEXT)
+            return
+        if lower.startswith("!price"):
+            args = _parse_args(content, "!price")
+            if not args:
+                await msg.reply("Usage: `!price TICKER`")
+                return
+            await msg.reply(_cmd_price(args[0].upper()))
+            return
+        if lower.startswith("!quote"):
+            args = _parse_args(content, "!quote")
+            if not args:
+                await msg.reply("Usage: `!quote TICKER`")
+                return
+            await msg.reply(_cmd_quote(args[0].upper()))
+            return
+        if lower.startswith("!info"):
+            args = _parse_args(content, "!info")
+            if not args:
+                await msg.reply("Usage: `!info TICKER`")
+                return
+            await msg.reply(_cmd_info(args[0].upper()))
+            return
+        if lower in ("!sectors", "!sector"):
+            await msg.reply(_cmd_sectors())
+            return
+        if lower.startswith("!industries") or lower.startswith("!industry"):
+            cmd = "!industries" if lower.startswith("!industries") else "!industry"
+            args = _parse_args(content, cmd)
+            if not args:
+                await msg.reply("Usage: `!industries <sector>`")
+                return
+            await msg.reply(_cmd_industries(" ".join(args)))
+            return
+        if lower.startswith("!tickers"):
+            args = _parse_args(content, "!tickers")
+            if not args:
+                await msg.reply("Usage: `!tickers <sector> [industry]`")
+                return
+            from julia import tickers_store
 
-        comment = latest_submission.reply(message)
-        comment_id = comment.id
-        await msg.reply(f"Commented: '{message}' (comment id: {comment_id})")
+            sectors = [s["sector"] for s in tickers_store.list_sectors()]
+            joined = " ".join(args)
+            sector = None
+            industry = None
+            # Prefer longest sector name match against the full arg string.
+            for candidate in sorted(sectors, key=len, reverse=True):
+                if joined.lower() == candidate.lower():
+                    sector = candidate
+                    break
+                prefix = candidate.lower() + " "
+                if joined.lower().startswith(prefix):
+                    sector = candidate
+                    industry = joined[len(candidate) :].strip() or None
+                    break
+            if sector is None:
+                # Fall back: first token as sector, rest as industry.
+                sector = args[0]
+                industry = " ".join(args[1:]) or None
+            await msg.reply(_cmd_tickers(sector, industry))
+            return
+        if lower.startswith("!search"):
+            args = _parse_args(content, "!search")
+            if not args:
+                await msg.reply("Usage: `!search <query>`")
+                return
+            await msg.reply(_cmd_search(" ".join(args)))
+            return
+    except Exception as e:  # noqa: BLE001
+        traceback.print_exc()
+        await msg.reply(f"Error: `{type(e).__name__}: {e}`")
 
 
-client.run(TOKEN)
+def build_client() -> discord.Client:
+    intents = Intents.default()
+    intents.message_content = True
+    client = discord.Client(intents=intents)
+
+    @client.event
+    async def on_ready() -> None:
+        print(f"[discord] logged in as {client.user} (id={client.user and client.user.id})")
+        channel_id = os.getenv("DISCORD_CHANNEL_ID")
+        if not channel_id:
+            return
+        try:
+            channel = client.get_channel(int(channel_id))
+            if channel is None:
+                channel = await client.fetch_channel(int(channel_id))
+            if channel is not None:
+                await channel.send(
+                    "Julia stock bot online. Type `!help` for commands."
+                )
+        except Exception as e:  # noqa: BLE001
+            print(f"[discord] ready greeting failed: {e!r}")
+
+    @client.event
+    async def on_message(msg: discord.Message) -> None:
+        if msg.author.bot:
+            return
+        await _handle_message(msg)
+
+    return client
+
+
+def run_bot(token: Optional[str] = None) -> None:
+    """Block forever on the Discord gateway."""
+    token = token or os.getenv("DISCORD_BOT_TOKEN")
+    if not token:
+        raise SystemExit(
+            "DISCORD_BOT_TOKEN is not set. Create a Discord application at "
+            "https://discord.com/developers/applications and put the bot "
+            "token in the julia host `.env`."
+        )
+    client = build_client()
+    client.run(token)
+
+
+if __name__ == "__main__":
+    run_bot()

--- a/uv.lock
+++ b/uv.lock
@@ -1224,6 +1224,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "discord" },
     { name = "markupsafe" },
     { name = "matplotlib" },
     { name = "numpy" },
@@ -1242,7 +1243,6 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "chromadb" },
-    { name = "discord" },
     { name = "openai" },
     { name = "praw" },
     { name = "pydub" },
@@ -1256,7 +1256,6 @@ audio = [
     { name = "simpleaudio" },
 ]
 chat = [
-    { name = "discord" },
     { name = "praw" },
 ]
 llm = [
@@ -1274,8 +1273,7 @@ requires-dist = [
     { name = "chromadb", marker = "extra == 'all'", specifier = ">=1.3.4" },
     { name = "chromadb", marker = "extra == 'llm'", specifier = ">=1.3.4" },
     { name = "click", specifier = ">=8.1.8" },
-    { name = "discord", marker = "extra == 'all'", specifier = ">=2.3.2" },
-    { name = "discord", marker = "extra == 'chat'", specifier = ">=2.3.2" },
+    { name = "discord", specifier = ">=2.3.2" },
     { name = "markupsafe", specifier = "==3.0.2" },
     { name = "matplotlib", specifier = ">=3.11.0" },
     { name = "numpy", specifier = ">=2.0.2" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Folds a Julia Discord stock bot into EC2 deploy, same lifecycle as the price poller.

## What’s included
- Stock query bot (`!price`, `!quote`, `!info`, `!sectors`, `!industries`, `!tickers`, `!search`, `!help`)
- `scripts/discord_bot.py` — PID-managed process (`--status` / `--stop` / `--replace`)
- `./restart-discord-bot.sh` — start/stop/logs inside `julia-dashboard`
- `deploy.sh` step **4/5** starts it after the poller; **skips cleanly** if `DISCORD_BOT_TOKEN` is unset
- `discord` moved to core deps so the Docker image has it

## Host setup
On the julia EC2 `.env` (recreate the container after editing so Docker picks it up):

```bash
DISCORD_BOT_TOKEN=...        # new Discord app — don’t reuse another bot’s token
DISCORD_CHANNEL_ID=...       # optional ready-greeting channel
```

Then `./deploy.sh`, or just `./restart-discord-bot.sh` if the container is already up.

Create the app at https://discord.com/developers/applications, enable **Message Content Intent**, invite with Send Messages + Read History.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d14d871e-e61a-48e6-8a7e-0feacc5779a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d14d871e-e61a-48e6-8a7e-0feacc5779a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

