### PR TITLE
Clarify Discord Message Content Intent requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,11 @@ RH_PASSWORD=your_password
 ### Discord stock bot (optional)
 
 Create a **new** Discord application at https://discord.com/developers/applications
-(do not reuse another bot's token), enable **Message Content Intent**, invite the
-bot to your server, then add to `.env`:
+(do not reuse another bot's token), then:
+
+1. **Bot → Privileged Gateway Intents** → enable **Message Content Intent** (required)
+2. Invite the bot (OAuth2 → URL Generator: scope `bot`, Send Messages / Read History)
+3. Add to `.env`:
 
 ```bash
 DISCORD_BOT_TOKEN=...          # required to start the bot

--- a/src/julia/discorder.py
+++ b/src/julia/discorder.py
@@ -427,7 +427,16 @@ def run_bot(token: Optional[str] = None) -> None:
             "token in the julia host `.env`."
         )
     client = build_client()
-    client.run(token)
+    try:
+        client.run(token)
+    except discord.errors.PrivilegedIntentsRequired as e:
+        raise SystemExit(
+            "Discord rejected privileged intents.\n"
+            "In https://discord.com/developers/applications → your app → "
+            "Bot → Privileged Gateway Intents, enable **Message Content "
+            "Intent**, save, then re-run ./restart-discord-bot.sh.\n"
+            f"({e})"
+        ) from e
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Clearer fatal error when Discord rejects privileged intents (Message Content Intent not enabled in the Developer Portal).

## Why
`./restart-discord-bot.sh` fails with `PrivilegedIntentsRequired` until **Bot → Privileged Gateway Intents → Message Content Intent** is enabled for the Julia Discord app.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d14d871e-e61a-48e6-8a7e-0feacc5779a6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d14d871e-e61a-48e6-8a7e-0feacc5779a6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

